### PR TITLE
"init" support added

### DIFF
--- a/cinch/bin/wrappers.py
+++ b/cinch/bin/wrappers.py
@@ -3,14 +3,14 @@ from __future__ import print_function
 from contextlib import contextmanager
 from plumbum import local
 from plumbum.commands.processes import ProcessExecutionError
-from os import path, chdir, getcwd
 from traceback import print_exc
 
+import os
 import yaml
 import sys
 
 
-BASE = path.abspath(path.join(path.dirname(__file__), '..'))
+BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 
 def call_ansible(inventory, playbook, *args):
@@ -27,7 +27,7 @@ def call_ansible(inventory, playbook, *args):
     # Construct the arguments to pass to Ansible by munging the arguments
     # provided to this method
     ansible_args = [
-        path.join(BASE, playbook),
+        os.path.join(BASE, playbook),
         '-i', inventory,
         '-v',
         '--ssh-common-args=-o StrictHostKeyChecking=no'
@@ -44,19 +44,100 @@ def call_linchpin(work_dir, arg):
 
     :param work_dir: The linch-pin working directory that contains a PinFile
     and associated configuration files
-    :param args: An array of other command-line arguments to linchpin to pass
+    :param arg: A single argument to pass to the linchpin command
     :return: The exit code returned from linchpin, or 255 if errors come from
     elsewhere
     """
     # cinch will only support a subset of linchpin subcommands
-    supported_cmds = ['rise', 'drop']
+    supported_cmds = ['rise', 'drop', 'init']
     if arg not in supported_cmds:
         raise Exception('linchpin command "{0}" not '
                         'supported by cinch'.format(arg))
+
+    # If we are to ask linch-pin to interact with infrastructure we will check
+    # for some required configuration items and set up them for later use
+    if arg != 'init':
+        inventory_file = get_inventory(work_dir)
+        inventory_path = os.path.join(work_dir, 'inventory', inventory_file)
+
+    # For drop/teardown, we must run our teardown playbook(s) *before*
+    # linchpin terminates the instance(s)
+    if arg == 'drop':
+        call_ansible(inventory_path, 'teardown.yml')
+
+    # As of right now the linch-pin working directory is not configurable, so
+    # we essentially have a 'pushd' here to switch to the linch-pin working
+    # directory as needed. This code can be removed if the following issue is
+    # resolved:
+    # https://github.com/CentOS-PaaS-SIG/linch-pin/issues/119
+    @contextmanager
+    def pushd(new_dir):
+        previous_dir = os.getcwd()
+        os.chdir(new_dir)
+        yield
+        os.chdir(previous_dir)
+
+    # Execute the 'linchpin' command
+    with pushd(work_dir):
+        linchpin = local['linchpin']
+        exit_code = command_handler(linchpin, arg)
+
+    # Set up a linch-pin+cinch configuration skeleton for later use if the
+    # 'init' subcommand was executed previously
+    if arg == 'init':
+        # Consistent filename to use for various linch-pin YAML configurations
+        # for 'cinchpin'
+        config_file = 'cinch.yml'
+        # Cinch layout and topology paths to be added to linch-pin PinFile
+        config_setup = {
+            'cinch': {
+                'topology': config_file,
+                'layout': config_file
+            }
+        }
+        # These are the first-level config paths that linch-pin creates for us
+        # in the working directory
+        local_paths = ['layouts', 'topologies']
+        # Link to our docs with configuration examples
+        docs = 'http://example.com'
+        # Skeleton text to insert in YAML config files
+        skel_text = '''---
+# Add your cinch {0} configuration here
+# Examples: {1}
+'''
+
+        # Overwrite the PinFile that linch-pin created with our configuration
+        pin_file = os.path.join(work_dir, 'PinFile')
+        with open(pin_file, 'w') as f:
+            yaml.dump(config_setup, f, default_flow_style=False)
+
+        # Write out the skeletons and inform the user that they exist
+        for local_path in local_paths:
+            path = os.path.join(work_dir, local_path, config_file)
+            with open(path, 'w') as f:
+                f.write(skel_text.format(local_path, docs))
+            print('Please configure this file to use cinch: ' + path)
+        print('Example configurations: ' + docs)
+
+    # If linchpin is asked to provision resources, we will then run our
+    # cinch provisioning playbook
+    if arg == 'rise' and exit_code == 0:
+        call_ansible(inventory_path, 'site.yml')
+
+
+def get_inventory(work_dir):
+    """
+    Basic checks for cinch compatibility in the linch-pin working directory,
+    and if successful, we produce a topology file for cinch to use.
+
+    :param work_dir: The linch-pin working directory as created by 'linchpin
+    init' or 'cinchpin init'
+    :return: The topology file to pass to the 'cinch' command
+    """
     # Attempt to open the linch-pin PinFile
     try:
-        with open(path.join(work_dir, 'PinFile')) as pin_file:
-            pin_file_yaml = yaml.safe_load(pin_file)
+        with open(os.path.join(work_dir, 'PinFile'), 'r') as f:
+            pin_file_yaml = yaml.safe_load(f)
     except IOError:
         print('linch-pin PinFile not found in ' + work_dir)
         sys.exit(1)
@@ -72,41 +153,15 @@ def call_linchpin(work_dir, arg):
     #  The inventory file generated by linchpin that will be used by cinch for
     #  configuration
     try:
-        topology_path = path.join(work_dir, 'topologies', topology)
+        topology_path = os.path.join(work_dir, 'topologies', topology)
         with open(topology_path) as topology_file:
             topology_yaml = yaml.safe_load(topology_file)
-    except IOError:
-        print('linch-pin topology file not found at ' +
+        inventory_file = topology_yaml['topology_name'] + '.inventory'
+    except (IOError, TypeError):
+        print('linch-pin topology file not found or malformed: ' +
               topology_path)
         sys.exit(1)
-    inventory_file = topology_yaml['topology_name'] + '.inventory'
-
-    # For drop/teardown, we must run our teardown playbook(s) *before*
-    # linchpin terminates the instance(s)
-    if arg == 'drop':
-        call_ansible(path.join(work_dir, 'inventory', inventory_file),
-                     'teardown.yml')
-
-    # As of right now the linch-pin working directory is not configurable, so
-    # we essentially have a 'pushd' here to switch to the linch-pin working
-    # directory as needed. This code can be removed if the following issue is
-    # resolved:
-    # https://github.com/CentOS-PaaS-SIG/linch-pin/issues/119
-    @contextmanager
-    def pushd(new_dir):
-        previous_dir = getcwd()
-        chdir(new_dir)
-        yield
-        chdir(previous_dir)
-
-    with pushd(work_dir):
-        linchpin = local['linchpin']
-        exit_code = command_handler(linchpin, arg)
-    # If linchpin is asked to provision resources, we will then run our
-    # cinch playbooks
-    if arg == 'rise' and exit_code == 0:
-        call_ansible(path.join(work_dir, 'inventory', inventory_file),
-                     'site.yml')
+    return inventory_file
 
 
 def command_handler(command, args):


### PR DESCRIPTION
* Imported the entire 'os' module since it is used often and updated
references to it

* Fixed some outdated docstrings

* Moved inventory file validation checking and loading to a separate
function for readability

* Added a configuration skeleton for ease of use

* Elected to overwrite the example PinFile provided by linch-pin since
the example contains many sections that we do not use

* Improved error handling for topology files