### PR TITLE
Skip Jenkins 2 initial setup

### DIFF
--- a/cinch/roles/jenkins_master/defaults/main.yml
+++ b/cinch/roles/jenkins_master/defaults/main.yml
@@ -66,6 +66,8 @@ jenkins_java_options:
   - -Djenkins.security.ApiTokenProperty.showTokenToAdmins=true
   # Allows all parameters to be passed between jobs in trigger pipelines
   - -Dhudson.model.ParametersAction.keepUndefinedParameters=true
+  # Skip Jenkins 2 initial setup
+  - -Djenkins.install.runSetupWizard=false
   # Increase max Java heap size
   - -Xmx{{ java_heap_size }}
 # the path to the Java executable


### PR DESCRIPTION
After installation of Jenkins 2, there is initial setup page and Jenkins is installed with initialPassword, then it is not possible to configure users and plugins  #48.
With added jenkins java option this setup is skipped and Jenkins is installed unsecured, like Jenkins 1.6x.