### PR TITLE
roles/jenkins_slave: support inject of env vars

### DIFF
--- a/cinch/roles/jenkins_slave/defaults/main.yml
+++ b/cinch/roles/jenkins_slave/defaults/main.yml
@@ -7,6 +7,8 @@ jenkins_url: http://example.com:8080/jenkins/
 jslave_name: "{{ inventory_hostname }}"
 # The label for this slave
 jslave_label: ops-jslave
+# Additional list of variables injected into jswarm's environment
+jswarm_environment: []
 # Number of executor processes on the slave - modify based on system capacity and load
 jswarm_execs: 10
 # Extra command line args passed to jswarm

--- a/cinch/roles/jenkins_slave/tasks/main.yml
+++ b/cinch/roles/jenkins_slave/tasks/main.yml
@@ -69,6 +69,14 @@
     mode: 0644
   notify: restart swarm
 
+- name: inject additional variables to swarm's environment
+  lineinfile:
+    dest: /etc/sysconfig/jenkins_swarm
+    line: "{{ item }}"
+    state: present
+  with_items: "{{ jswarm_environment }}"
+  notify: restart swarm
+
 - name: upload swarm systemd file
   template:
     src: swarm.service


### PR DESCRIPTION
This patch provides a convient way how to add additional
environment variables to a running jswarm client.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>