### PR TITLE
Remove beaker-project.org repos from el7 hosts

### DIFF
--- a/cinch/group_vars/cent7
+++ b/cinch/group_vars/cent7
@@ -10,7 +10,6 @@ _repositories:
 
 _download_repositories:
   - http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo
-  - https://beaker-project.org/yum/beaker-client-CentOS.repo
 
 rpm_key_imports:
   - key: http://pkg.jenkins-ci.org/redhat-stable/jenkins.io.key

--- a/cinch/group_vars/rhel7
+++ b/cinch/group_vars/rhel7
@@ -23,7 +23,6 @@ all_repositories:
 # These types of repositories will download the requested URL into the /etc/yum.repos.d
 # folder in order to enable them
 all_download_repositories:
-  beaker: https://beaker-project.org/yum/beaker-client-RedHatEnterpriseLinux.repo
   jenkins: http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo
 
 jenkins_slave_repositories:
@@ -31,8 +30,7 @@ jenkins_slave_repositories:
   - "{{ all_repositories.optional }}"
   - "{{ all_repositories.epel }}"
 
-jenkins_slave_download_repositories:
-  - "{{ all_download_repositories.beaker }}"
+jenkins_slave_download_repositories: []
 
 jenkins_master_repositories:
   - "{{ all_repositories.latest }}"
@@ -41,5 +39,4 @@ jenkins_master_repositories:
   - "{{ all_repositories.openstack }}"
 
 jenkins_master_download_repositories:
-  - "{{ all_download_repositories.beaker }}"
   - "{{ all_download_repositories.jenkins }}"


### PR DESCRIPTION
The beaker-client package is now available in EPEL, which both the cent7
and rhel7 groups install. As a result, adding the beaker-project.org
repos to systems using those group vars is redundant, so those repos
have been removed.

Tested on cent7 and rhel7, beaker-client (and beaker-common) are available on these boxen from both epel and epel-testing.

closes #70 