### PR TITLE
Added error reporting for swarm service failures via systemd and upstart #72

### DIFF
--- a/cinch/roles/jenkins_slave/tasks/check_swarm_errors.yml
+++ b/cinch/roles/jenkins_slave/tasks/check_swarm_errors.yml
@@ -1,0 +1,12 @@
+# Reporting errors in a readable, pretty-print format must be done in two steps
+# here since the 'fail' module cannot split newlines.
+
+# The service_swarm_err_output var is set by the check_swarm_systemd.yml or
+# check_swarm_upstart.yml playbooks, depending on which init system is in use.
+- name: report errors for swarm service
+  debug: var=service_swarm_err_output.stdout.split('\n')
+
+- name: exit with failure if swarm service could not connect to the master
+  fail:
+    msg:
+      Swarm failed to connect to the master. See prior debug output for details.

--- a/cinch/roles/jenkins_slave/tasks/check_swarm_systemd.yml
+++ b/cinch/roles/jenkins_slave/tasks/check_swarm_systemd.yml
@@ -1,0 +1,17 @@
+- name: check if swarm connected to the master with systemd
+  command: systemctl status swarm
+  ignore_errors: yes
+  changed_when: false
+  register: service_swarm_status
+
+- name: grab errors for the last run of the systemd swarm service
+  shell: >
+    journalctl --no-pager -u swarm -o cat
+    _PID=$(systemctl show swarm --property=ExecMainPID
+    | cut -d '=' -f 2)
+  register: service_swarm_err_output
+  when: service_swarm_status|failed
+
+- name: report errors for systemd swarm service
+  include: check_swarm_errors.yml
+  when: service_swarm_status|failed

--- a/cinch/roles/jenkins_slave/tasks/check_swarm_systemd.yml
+++ b/cinch/roles/jenkins_slave/tasks/check_swarm_systemd.yml
@@ -1,9 +1,14 @@
 - name: check if swarm connected to the master with systemd
   command: systemctl status swarm
-  ignore_errors: yes
+  ignore_errors: true
   changed_when: false
   register: service_swarm_status
 
+# Some shell magic is required here to grab the log output from *only* the last
+# run of the swarm service in systemd.  To do this, we find the last PID that
+# was used to start the service using systemctl, and we extract just the PID
+# via 'cut'.  Then we pass that PID to journalctl to give us only the log data
+# we want.
 - name: grab errors for the last run of the systemd swarm service
   shell: >
     journalctl --no-pager -u swarm -o cat

--- a/cinch/roles/jenkins_slave/tasks/check_swarm_upstart.yml
+++ b/cinch/roles/jenkins_slave/tasks/check_swarm_upstart.yml
@@ -1,0 +1,14 @@
+- name: check if swarm connected to the master with upstart
+  command: "grep 'INFO: Connected' /var/log/jenkins-swarm.log"
+  ignore_errors: yes
+  changed_when: false
+  register: service_swarm_status
+
+- name: grab errors for the last run of the upstart swarm service
+  command: cat /var/log/jenkins-swarm.log
+  register: service_swarm_err_output
+  when: service_swarm_status|failed
+
+- name: report errors for upstart swarm service
+  include: check_swarm_errors.yml
+  when: service_swarm_status|failed

--- a/cinch/roles/jenkins_slave/tasks/check_swarm_upstart.yml
+++ b/cinch/roles/jenkins_slave/tasks/check_swarm_upstart.yml
@@ -1,6 +1,6 @@
 - name: check if swarm connected to the master with upstart
   command: "grep 'INFO: Connected' /var/log/jenkins-swarm.log"
-  ignore_errors: yes
+  ignore_errors: true
   changed_when: false
   register: service_swarm_status
 

--- a/cinch/roles/jenkins_slave/tasks/main.yml
+++ b/cinch/roles/jenkins_slave/tasks/main.yml
@@ -61,6 +61,15 @@
     jswarm_extra_args: "{{ '{% raw %}{{ default .Env.JSWARM_EXTRA_ARGS \"\" }}{% endraw %}' }}"
   when: ansible_connection == 'docker'
 
+# The default swarm client timeout is 10 seconds.  This value should never be
+# set to less than 10 seconds, and increasing it should not be necessary.
+# It is not recommended to change this value, but it is set here in order to
+# define this value in a single location for the systemd and upstart service
+# templates.
+- name: set variable for swarm service retry timer
+  set_fact:
+    swarm_retry_timer: 10
+
 - name: upload swarm config file
   template:
     src: sysconfig_jenkins_swarm
@@ -106,14 +115,14 @@
     enabled: true
   when: ansible_connection != 'docker'
 
-# This timeout is longer than the default swarm client timeout of 10 seconds.
 # There is an unavoidable race condition when running the swarm client within
-# an init system. The value of 15 is used to help ensure that errors are not
-# caught during a subsequent, and unrelated service restart. Essentially, we
-# are checking the status directly in-between service restarts.
+# an init system. The value of swarm_retry_timer * 1.5 is used to help ensure
+# that errors are not caught during a subsequent, and unrelated service
+# restart.  Essentially, we are checking the status directly in-between service
+# restarts.
 - name: wait for the swarm connection timeout
   pause:
-    seconds: 15
+    seconds: "{{ (swarm_retry_timer * 1.5)|int }}"
   when: ansible_connection != 'docker'
 
 - name: check swarm service status when using systemd

--- a/cinch/roles/jenkins_slave/tasks/main.yml
+++ b/cinch/roles/jenkins_slave/tasks/main.yml
@@ -105,3 +105,21 @@
     state: started
     enabled: true
   when: ansible_connection != 'docker'
+
+# This timeout is longer than the default swarm client timeout of 10 seconds.
+# There is an unavoidable race condition when running the swarm client within
+# an init system. The value of 15 is used to help ensure that errors are not
+# caught during a subsequent, and unrelated service restart. Essentially, we
+# are checking the status directly in-between service restarts.
+- name: wait for the swarm connection timeout
+  pause:
+    seconds: 15
+  when: ansible_connection != 'docker'
+
+- name: check swarm service status when using systemd
+  include: check_swarm_systemd.yml
+  when: ansible_connection != 'docker' and ansible_service_mgr == 'systemd'
+
+- name: check swarm service status when using upstart
+  include: check_swarm_upstart.yml
+  when: ansible_connection != 'docker' and ansible_service_mgr == 'upstart'

--- a/cinch/roles/jenkins_slave/templates/swarm.service
+++ b/cinch/roles/jenkins_slave/templates/swarm.service
@@ -6,13 +6,11 @@ User={{ jenkins_user }}
 EnvironmentFile=/etc/sysconfig/jenkins_swarm
 Restart=on-failure
 
-# Wait 10 seconds (swarm client default) for the service to fail; code in
-# roles/jenkins_slave/tasks/main.yml depends on this value.
-TimeoutStartSec=10s
+# Wait for the service to fail
+TimeoutStartSec={{ swarm_retry_timer }}s
 
-# Restart failed service after 10 seconds; code in
-# roles/jenkins_slave/tasks/main.yml depends on this value.
-RestartSec=10s
+# Restart failed service after timer expires
+RestartSec={{ swarm_retry_timer }}s
 
 # -retry 0 in this script disables the built-in retry functionality in swarm so
 # the init system can manage it

--- a/cinch/roles/jenkins_slave/templates/swarm.service
+++ b/cinch/roles/jenkins_slave/templates/swarm.service
@@ -2,7 +2,20 @@
 After=network-online.target
 Wants=network-online.target
 [Service]
+User={{ jenkins_user }}
 EnvironmentFile=/etc/sysconfig/jenkins_swarm
+Restart=on-failure
+
+# Wait 10 seconds (swarm client default) for the service to fail; code in
+# roles/jenkins_slave/tasks/main.yml depends on this value.
+TimeoutStartSec=10s
+
+# Restart failed service after 10 seconds; code in
+# roles/jenkins_slave/tasks/main.yml depends on this value.
+RestartSec=10s
+
+# -retry 0 in this script disables the built-in retry functionality in swarm so
+# the init system can manage it
 ExecStart={{ jenkins_java_cmd }} \
           $SWARM_JAVA_ARGS \
           -jar "{{ jswarm_local_directory }}/{{ jswarm_filename }}" \
@@ -11,10 +24,10 @@ ExecStart={{ jenkins_java_cmd }} \
           -executors "$SWARM_EXECUTORS" \
           -labels "$SWARM_SLAVE_LABEL" \
           -fsroot "$SWARM_ROOT" \
+          -retry 0 \
           $SWARM_USERNAME \
           $SWARM_PASSWORD \
           $SWARM_EXTRA_ARGS
-Restart=on-failure
-User={{ jenkins_user }}
+
 [Install]
 WantedBy=multi-user.target

--- a/cinch/roles/jenkins_slave/templates/swarm.upstart.conf
+++ b/cinch/roles/jenkins_slave/templates/swarm.upstart.conf
@@ -4,6 +4,21 @@ start on runlevel [2345]
 stop on runlevel [016]
 respawn
 respawn limit unlimited
+
+# Wait 10 seconds (swarm client default) for the service to fail; code in
+# roles/jenkins_slave/tasks/main.yml depends on this value.
+kill timeout 10
+
+# Restart failed service after 10 seconds; code in
+# roles/jenkins_slave/tasks/main.yml depends on this value.
+post-stop exec sleep 10
+
+# -retry 0 in this script disables the built-in retry functionality in swarm so
+# the init system can manage it.
+# We use 'tee' to write the swarm output to syslog via 'logger' as well as
+# wrinting the output from the *last* run of the swarm client to a separate log
+# file that can be read by Ansible. upstart doesn't allow us to easily grab the
+# log output of the most recent service restart.
 script
     exec su -s /bin/sh \
         -c 'exec "$0" "$@"' {{ jenkins_user }} -- \
@@ -15,7 +30,9 @@ script
         -executors {{ jswarm_execs }} \
         -labels "{{ jslave_label }}" \
         -fsroot "{{ jswarm_home }}" \
-        -mode exclusive -disableSslVerification -deleteExistingClients \
-        2>&1 | logger -t jenkins-swarm
+        -retry 0 \
+        {{ (jenkins_slave_username == '') | ternary('', '-username') }} {{ jenkins_slave_username }} \
+        {{ (jenkins_slave_password == '') | ternary('', '-password') }} {{ jenkins_slave_password }} \
+        -mode exclusive -disableSslVerification -deleteExistingClients {{ jswarm_extra_args }} \
+        2>&1 | tee /var/log/jenkins-swarm.log | logger -t jenkins-swarm
 end script
-post-stop exec sleep 3

--- a/cinch/roles/jenkins_slave/templates/swarm.upstart.conf
+++ b/cinch/roles/jenkins_slave/templates/swarm.upstart.conf
@@ -5,13 +5,11 @@ stop on runlevel [016]
 respawn
 respawn limit unlimited
 
-# Wait 10 seconds (swarm client default) for the service to fail; code in
-# roles/jenkins_slave/tasks/main.yml depends on this value.
-kill timeout 10
+# Wait for the service to fail
+kill timeout {{ swarm_retry_timer }}
 
-# Restart failed service after 10 seconds; code in
-# roles/jenkins_slave/tasks/main.yml depends on this value.
-post-stop exec sleep 10
+# Restart failed service after timer expires
+post-stop exec sleep {{ swarm_retry_timer }}
 
 # -retry 0 in this script disables the built-in retry functionality in swarm so
 # the init system can manage it.


### PR DESCRIPTION
#72 

* Modified service templates to allow the init system to manage swarm's
retry behavior

* Ansible will now fail if the swarm client cannot connect to the
master, and will pretty-print the error message for human consumption.

* Service timeouts and retry delays have been set to 10 seconds to align
with the default behavior of the swarm client.

* Re-ordered lines in service templates to make them easier to compare
side-by-side

* Fixed an issue in the upstart service template where the
authentication parameters were not set