### PR TITLE
nginx: Ensure installation of libsemanage-python 

### DIFF
--- a/cinch/roles/nginx/tasks/selinux.yml
+++ b/cinch/roles/nginx/tasks/selinux.yml
@@ -1,3 +1,8 @@
+- name: ensure libsemanage-python is installed
+  package:
+    name: libsemanage-python
+    state: installed
+
 - name: enable selinux overrides
   seboolean:
     name: "{{ item }}"

--- a/cinch/roles/nginx/tasks/selinux.yml
+++ b/cinch/roles/nginx/tasks/selinux.yml
@@ -1,7 +1,7 @@
 - name: ensure libsemanage-python is installed
   package:
     name: libsemanage-python
-    state: installed
+    state: present
 
 - name: enable selinux overrides
   seboolean:


### PR DESCRIPTION
In order to manage SELinux rules, this package must be installed (and apparently ain't in older RHEL versions (<=7.2)