### PR TITLE
linchpin 1.0.x compatibility

### DIFF
--- a/cinch/library/jenkins_script.py
+++ b/cinch/library/jenkins_script.py
@@ -1,0 +1,208 @@
+#!/usr/bin/python
+
+# encoding: utf-8
+
+# In cinch, this file was vendored from upstream Ansible.  It can be removed
+# once linchpin depends on ansible>=2.3
+# https://docs.ansible.com/ansible/jenkins_script_module.html
+
+# (c) 2016, James Hogarth <james.hogarth@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+author: James Hogarth
+module: jenkins_script
+short_description: Executes a groovy script in the jenkins instance
+version_added: '2.3'
+description:
+    - The C(jenkins_script) module takes a script plus a dict of values
+      to use within the script and returns the result of the script being run.
+
+options:
+  script:
+    description:
+      - The groovy script to be executed.
+        This gets passed as a string Template if args is defined.
+    required: true
+    default: null
+  url:
+    description:
+      - The jenkins server to execute the script against. The default is a local
+        jenkins instance that is not being proxied through a webserver.
+    required: false
+    default: http://localhost:8080
+  validate_certs:
+    description:
+      - If set to C(no), the SSL certificates will not be validated.
+        This should only set to C(no) used on personally controlled sites
+        using self-signed certificates as it avoids verifying the source site.
+    required: false
+    default: True
+  user:
+    description:
+      - The username to connect to the jenkins server with.
+    required: false
+    default: null
+  password:
+    description:
+      - The password to connect to the jenkins server with.
+    required: false
+    default: null
+  args:
+    description:
+      - A dict of key-value pairs used in formatting the script.
+    required: false
+    default: null
+
+notes:
+    - Since the script can do anything this does not report on changes.
+      Knowing the script is being run it's important to set changed_when
+      for the ansible output to be clear on any alterations made.
+
+'''
+
+EXAMPLES = '''
+- name: Obtaining a list of plugins
+  jenkins_script:
+    script: 'println(Jenkins.instance.pluginManager.plugins)'
+    user: admin
+    password: admin
+
+- name: Setting master using a variable to hold a more complicate script
+  vars:
+    setmaster_mode: |
+        import jenkins.model.*
+        instance = Jenkins.getInstance()
+        instance.setMode(${jenkins_mode})
+        instance.save()
+
+- name: use the variable as the script
+  jenkins_script:
+    script: "{{ setmaster_mode }}"
+    args:
+      jenkins_mode: Node.Mode.EXCLUSIVE
+
+- name: interacting with an untrusted HTTPS connection
+  jenkins_script:
+    script: "println(Jenkins.instance.pluginManager.plugins)"
+    user: admin
+    password: admin
+    url: https://localhost
+    validate_certs: no
+'''
+
+RETURN = '''
+output:
+    description: Result of script
+    returned: success
+    type: string
+    sample: 'Result: true'
+'''
+
+import json
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
+try:
+    # python2
+    from urllib import urlencode
+except ImportError:
+    # python3
+    from urllib.parse import urlencode
+
+
+def is_csrf_protection_enabled(module):
+    resp, info = fetch_url(module,
+                           module.params['url'] + '/api/json',
+                           method='GET')
+    if info["status"] != 200:
+        module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"])
+
+    content = resp.read()
+    return json.loads(content).get('useCrumbs', False)
+
+
+def get_crumb(module):
+    resp, info = fetch_url(module,
+                           module.params['url'] + '/crumbIssuer/api/json',
+                           method='GET')
+    if info["status"] != 200:
+        module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"])
+
+    content = resp.read()
+    return json.loads(content)
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            script=dict(required=True, type="str"),
+            url=dict(required=False, type="str", default="http://localhost:8080"),
+            validate_certs=dict(required=False, type="bool", default=True),
+            user=dict(required=False, no_log=True, type="str", default=None),
+            password=dict(required=False, no_log=True, type="str", default=None),
+            args=dict(required=False, type="dict", default=None)
+        )
+    )
+
+    if module.params['user'] is not None:
+        if module.params['password'] is None:
+            module.fail_json(msg="password required when user provided")
+        module.params['url_username'] = module.params['user']
+        module.params['url_password'] = module.params['password']
+        module.params['force_basic_auth'] = True
+
+    if module.params['args'] is not None:
+        from string import Template
+        script_contents = Template(module.params['script']).substitute(module.params['args'])
+    else:
+        script_contents = module.params['script']
+
+    headers = {}
+    if is_csrf_protection_enabled(module):
+        crumb = get_crumb(module)
+        headers = {crumb['crumbRequestField']: crumb['crumb']}
+
+    resp, info = fetch_url(module,
+                           module.params['url'] + "/scriptText",
+                           data=urlencode({'script': script_contents}),
+                           headers=headers,
+                           method="POST")
+
+    if info["status"] != 200:
+        module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"])
+
+    result = resp.read()
+
+    if 'Exception:' in result and 'at java.lang.Thread' in result:
+        module.fail_json(msg="script failed with stacktrace:\n " + result)
+
+    module.exit_json(
+        output=result,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/cinch/playbooks/install-rhel7.yml
+++ b/cinch/playbooks/install-rhel7.yml
@@ -14,6 +14,8 @@
     temp_dir: "{{ venv_dir }}/tmp"
     python: "{{ venv_dir }}/bin/python"
     delete_venv: false
+    latest_tip: false
+    beaker_kerberos: true
 
   tasks:
     - name: fail if we are not running this playbook on RHEL7
@@ -76,25 +78,30 @@
       args:
         creates: "{{ venv_dir }}/lib/python2.7/site-packages/setuptools"
 
-    - name: install cinch using pip
+    - name: install released versions of cinch+linch-pin using pip
       pip:
         name: cinch
         virtualenv: "{{ venv_dir }}"
         extra_args: -U
+      when: not (latest_tip|bool)
 
     # This pip install should be non-editable, but the pip module in Ansible
     # 1.8.4. does not support that flag
-    - name: install linch-pin from master branch instead of latest release from pypi
+    - name: install latest tip of cinch+linch-pin instead of latest release from pypi
       command: >-
-        "{{ python }}" "{{ venv_dir }}/bin/pip install" -U
-        git+https://github.com/CentOS-PaaS-SIG/linch-pin.git@master
-      when: (linchpin_master|bool)
+        "{{ venv_dir }}/bin/pip" install -U
+        https://github.com/CentOS-PaaS-SIG/linchpin/archive/develop.tar.gz
+        https://github.com/RedHatQE/cinch/archive/master.tar.gz
+      when: (latest_tip|bool)
 
-    - name: install python-krbV with pip to use kerberos with Beaker
+    - name: install beaker-client and python-krbV with pip to use kerberos with Beaker
       pip:
-        name: python-krbV
+        name: "{{ item }}"
         virtualenv: "{{ venv_dir }}"
         extra_args: -U
+      with_items:
+        - beaker-client
+        - python-krbV
       when: (beaker_kerberos|bool)
 
     ## https://dmsimard.com/2016/01/08/selinux-python-virtualenv-chroot-and-ansible-dont-play-nice/
@@ -105,17 +112,3 @@
         src: /usr/lib64/python2.7/site-packages/selinux
         dest: "{{ venv_dir }}/lib/python2.7/site-packages/selinux"
         state: link
-
-    # work-around for https://github.com/CentOS-PaaS-SIG/linch-pin/issues/124
-    - name: generate linch-pin config file
-      command: "{{ python }} {{ venv_dir }}/bin/linchpin config --reset"
-      args:
-        chdir: "{{ temp_dir }}"
-      tags:
-        - skip_ansible_lint
-
-    # work-around for https://github.com/CentOS-PaaS-SIG/linch-pin/issues/124
-    - name: copy linch-pin config file to search path
-      copy:
-        src: "{{ temp_dir }}/linchpin_config.yml"
-        dest: "{{ venv_dir }}/lib/python2.7/site-packages/linchpin_config.yml"

--- a/cinch/teardown.yml
+++ b/cinch/teardown.yml
@@ -1,5 +1,11 @@
+- name: wait for SSH
+  hosts: all
+  gather_facts: false
+  roles:
+    - check_ssh
+
 - name: teardown jenkins slaves
   become: true
   hosts: jenkins_slave
   roles:
-  - jenkins_slave_teardown
+    - jenkins_slave_teardown

--- a/jjb/ci-jslave-project-sample-defaults.yaml
+++ b/jjb/ci-jslave-project-sample-defaults.yaml
@@ -10,3 +10,4 @@
           url: 'https://example.com/cinch-topology-example.git'
           branches:
             - origin/master
+          basedir: cinch-example

--- a/jjb/ci-jslave-project-sample.yaml
+++ b/jjb/ci-jslave-project-sample.yaml
@@ -5,27 +5,22 @@
     node: master
     parameters:
       - choice:
-          name: example_parameter
+          name: PROVIDER
           choices:
-            - example1
-            - example2
+            - openstack-slave
+            - beaker-slave
     builders:
       - shell: |
             #!/bin/bash -ex
-
-            # Work-around until this PR is merged
-            # https://github.com/CentOS-PaaS-SIG/linch-pin/pull/121
-            creds_file="${{JENKINS_HOME}}/opt/cinch/lib/python2.7/site-packages/provision/roles/openstack/vars/os_creds.yml"
-            if [[ ! -f "$creds_file" ]]; then
-                cp "{topology_path}/os_creds.yml" "$creds_file"
-            fi
-
             source "${{JENKINS_HOME}}/opt/cinch/bin/activate"
-            cinchpin rise -w {topology_path}
+            cinchpin up -w {topology_path}/${{PROVIDER}}
     publishers:
       - archive:
-          artifacts: '{inventory_file}'
+          artifacts: '{topology_path}/${{PROVIDER}}/inventories/cinch-test.inventory'
           allow-empty: 'false'
+      - archive:
+          artifacts: '{topology_path}/${{PROVIDER}}/resources/cinch-test.output'
+          allow-empty: 'true'
       - trigger-parameterized-builds:
           - project: 'jslave-{project}-{topology}-2-runtest'
             current-parameters: true
@@ -42,11 +37,11 @@
     builders:
       - shell: |
             #!/bin/bash -ex
-            exit 0
+            echo "$JOB_NAME $BUILD_DISPLAY_NAME" > test_artifact.txt
     publishers:
       - archive:
-          artifacts: '**/**'
-          allow-empty: 'true'
+          artifacts: 'test_artifact.txt'
+          allow-empty: 'false'
       - trigger-parameterized-builds:
           - project: 'jslave-{project}-{topology}-3-teardown'
             current-parameters: true
@@ -58,12 +53,22 @@
     builders:
       - copyartifact:
           project: 'jslave-{project}-{topology}-1-provision'
-          filter: '{inventory_file}'
-          target: '{inventory_file}'
+          filter: '{topology_path}/${{PROVIDER}}/inventories/cinch-test.inventory'
+          target: '{topology_path}/${{PROVIDER}}/inventories'
+          flatten: true
+      - copyartifact:
+          project: 'jslave-{project}-{topology}-1-provision'
+          filter: '{topology_path}/${{PROVIDER}}/resources/cinch-test.output'
+          target: '{topology_path}/${{PROVIDER}}/resources'
+          flatten: true
       - shell: |
             #!/bin/bash -ex
+            # work-around for output file naming issue with linchpin:
+            # https://github.com/CentOS-PaaS-SIG/linchpin/issues/294
+            ln -s ${{WORKSPACE}}/{topology_path}/${{PROVIDER}}/resources/cinch-test.output
+                ${{WORKSPACE}}/{topology_path}/${{PROVIDER}}/resources/cinch-test.output.yaml
             source "${{JENKINS_HOME}}/opt/cinch/bin/activate"
-            cinchpin drop -w {topology_path}
+            cinchpin destroy -w {topology_path}/${{PROVIDER}}
 
 - job-group:
     name: jslave-provision-runtest-teardown
@@ -80,5 +85,4 @@
     jobs:
       - jslave-provision-runtest-teardown
     jslave_name: cinch-slave
-    topology_path: 'examples/linch-pin-topologies/openstack'
-    inventory_file: '{topology_path}/inventories/cinch-test.inventory'
+    topology_path: 'cinch-example/examples/linch-pin-topologies'

--- a/jjb/install-rhel7.yaml
+++ b/jjb/install-rhel7.yaml
@@ -11,9 +11,9 @@
           default: false
           description: "Delete pre-existing cinch virtualenv and re-install"
       - bool:
-          name: LINCHPIN_MASTER
+          name: LATEST_TIP
           default: false
-          description: "Install linch-pin from master branch instead of latest release from pypi"
+          description: "Install latest tip of cinch+linch-pin instead of latest release from pypi"
       - bool:
           name: BEAKER_KERBEROS
           default: true
@@ -33,7 +33,7 @@
             #!/bin/bash -ex
             export PYTHONUNBUFFERED=1 # Enable real-time output for Ansible
             ansible-playbook -i localhost, -c local \
-                "${WORKSPACE}/cinch/cinch/install-rhel7.yml" \
+                "${WORKSPACE}/cinch/cinch/playbooks/install-rhel7.yml" \
                 -e delete_venv="${DELETE_VENV}" \
-                -e linchpin_master="${LINCHPIN_MASTER}" \
+                -e latest_tip="${LATEST_TIP}" \
                 -e beaker_kerberos="${BEAKER_KERBEROS}"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='cinch',
-    version='0.6.0',
+    version='0.7.0',
     description='Cinch continuous integration setup',
     long_description=description,
     url='https://github.com/RedHatQE/cinch',
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         'ansible>=2.2.1',
         'plumbum>=1.6.0',
-        'linchpin>=0.9'
+        'linchpin>=1.0.1'
     ],
     entry_points={
         'console_scripts': [

--- a/tests/lint.sh
+++ b/tests/lint.sh
@@ -34,5 +34,8 @@ find "${cinch}" -name 'jswarm.sh' -print0 |
 ###############################################################################
 # PYTHON LINT
 ###############################################################################
-find "${cinch}" -name '*.py' -print0 |
+# jenkins_script.py was vendored from upstream Ansible.
+# It can be removed once linchpin depends on ansible>=2.3
+# https://docs.ansible.com/ansible/jenkins_script_module.html
+find "${cinch}" -name '*.py' -not -name 'jenkins_script.py' -print0 |
 	xargs -0 -L 1 flake8


### PR DESCRIPTION
* Removed 'pushd/pop' work-around from wrappers.py now that linchpin has
the -w option on the CLI

* Updated docs links in wrappers.py to make the actual content easier to
find

* We don't need to raise an exception for unsupported linchpin commands
in cinchpin.  It's better to just print a normal error message for the
user.

* cinchpin now supports the new CLI options of linchpin and removes the
old ones

* Added some default linchpin CLI args that should be useful, such as
printing Ansible output, pointing to the correct workspace directory,
and setting the creds path to that of the workspace directory

* Added group_vars support to 'cinchpin init'

* Updated local_paths dictionary to account for the new group_vars
directory and to create the proper skeleton info

* Removed redundant places where we print an error and sys.exit(1).  We
can use sys.exit('msg') and get the same result.

* Vendored jenkins_script Ansible module because linchpin v1.0.x doesn't
depend on a recent enough version of Ansible to include the module
within Ansible itself

* Added the ability to optionally install the latest tip of
cinch+linchpin via the install-rhel7 Ansible playbook

* Added beaker-client package to install-rhel7 Ansible playbook

* Removed a couple of old work-arounds that from install-rhel7 Ansible
playbook that are no longer needed as of linchpin 1.0.x

* Added check_ssh role to teardown.yml.  This was missing before and was
a bug that was exposed under some conditions.

* Updated users.rst documention to reflect all the changes with linchpin
1.0.x and cinchpin

* JJB template now checks out example topologies into a subdirectory of
the Jenkins $WORKSPACE, which should be best practice

* Added $PROVIDER parameter to example JJB template, which allows for
easy switching between OpenStack and Beaker examples

* Removed work-arounds from JJB template which no longer apply due to
linchpin 1.0.x

* Updated JJB template to use the new cinchpin commands

* Added linchpin 'outputs' files as artifacts for the JJB template,
which are generated during provisioning and must be passed to the
teardown jobs

* The 'runtest' portion of the JJB template has a more meaningful
example other than just 'exit 0'

* Added outputs files to the copyartifact portion of the JJB template so
that teardown jobs can run as expected.  There's also a symlink
work-around for when some linchpin providers name their outputs file
with a different file extension.

* Bumped version in setup.py to 0.7.0, with a requirement for linchpin
1.0.1