### PR TITLE
roles/ntp: add support for configurable ntp servers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 v 0.7.1 (30 June 2017)
 - Updated Jenkins repo URL
 - Added ability to exclude changes to Jenkins plugins+configuration
+- Added configurable NTP server support
 
 v 0.7.0 (30 June 2017)
 - Baseline

--- a/cinch/group_vars/all
+++ b/cinch/group_vars/all
@@ -24,6 +24,16 @@ jswarm_version: 2.1
 jswarm_local_directory: /opt/jswarm
 jswarm_filename: swarm-client-{{ jswarm_version }}-jar-with-dependencies.jar
 
+# Override default distro NTP server configuration
+# Define the var ntp_servers as below to optionally override default NTP
+# server lines, including options such as iburst.
+# Left undefined, the distro defaults will be used.
+#ntp_servers:
+#    - "server 0.time.example.com iburst"
+#    - "server 1.time.example.com iburst"
+#    - "server 2.time.example.com iburst"
+#    - "server 3.time.example.com iburst"
+
 # Override these variables with an array of files to be uploaded as-is to the
 # destination host. Files in pre_upload_files will be uploaded before any other
 # code is run. Files in post_upload_files will be uploaded after all other tasks

--- a/cinch/roles/ntp/tasks/main.yml
+++ b/cinch/roles/ntp/tasks/main.yml
@@ -4,6 +4,23 @@
     name: ntp
     state: present
 
+- name: override ntp servers when ntp_servers is defined
+  block:
+    - name: remove existing ntp server values
+      lineinfile:
+        backup: yes
+        dest: /etc/ntp.conf
+        state: absent
+        regexp: "^server"
+
+    - name: add customized ntp servers
+      blockinfile:
+        dest: /etc/ntp.conf
+        insertafter: EOF
+        block: "{{ item }}"
+      with_items: "{{ ntp_servers }}"
+  when: ntp_servers is defined
+
 - name: start the NTP service
   become: true
   service:


### PR DESCRIPTION
- New `ntp_servers` override to specify optionally desired ntp server config.

- Example and brief note in group_vars/all

- If `ntp_servers` is not defined, distro defaults are used.

For https://github.com/RedHatQE/cinch/issues/135
