### PR TITLE
Added ability to disable Jenkins application configuration related to plugins and their settings. 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v 0.7.1 (30 June 2017)
 - Updated Jenkins repo URL
+- Added ability to exclude changes to Jenkins plugins+configuration
 
 v 0.7.0 (30 June 2017)
 - Baseline

--- a/cinch/roles/jenkins_master/defaults/main.yml
+++ b/cinch/roles/jenkins_master/defaults/main.yml
@@ -188,3 +188,8 @@ jenkins_executors: 10
 # This setting affects how the update center downloads plugin metadata
 # http://javadoc.jenkins-ci.org/jenkins/model/DownloadSettings.html
 jenkins_usebrowser: false
+# Enable or disable plugin installation and subsequent configuration of plugin
+# settings.  Disabling this will be useful for cases where Ansible will be used
+# to manage production Jenkins masters and changes to the Jenkins application
+# are not desired to lessen customer impact.
+jenkins_plugin_install_configure: true

--- a/cinch/roles/jenkins_master/tasks/main.yml
+++ b/cinch/roles/jenkins_master/tasks/main.yml
@@ -16,9 +16,11 @@
 
 - name: pin plugins to avoid upgrades
   include: pin_plugin.yml
+  when: jenkins_plugin_install_configure
 
 - name: plugins
   include: plugins.yml
+  when: jenkins_plugin_install_configure
 
 - name: make sure handlers are flushed
   meta: flush_handlers
@@ -29,3 +31,4 @@
 - name: application-level post configuration tasks
   become: false
   include: post_configure.yml
+  when: jenkins_plugin_install_configure


### PR DESCRIPTION
This will be useful for cases where Ansible
will be used to manage production Jenkins masters and changes to the
Jenkins application are not desired to lessen customer impact.