### PR TITLE
Ability to install packages on both master and slave

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@ v 0.7.1 (30 June 2017)
 - Updated Jenkins repo URL
 - Added ability to exclude changes to Jenkins plugins+configuration
 - Added configurable NTP server support
+- Added ability to install packages on both master and slave with single var.
+  This renames the `additional_packages` var to `jmaster_extra_rpms` to be
+  consistent with the existing `jslave_extra_rpms`, and adds a new var called
+  `extra_rpms` for use in the `jenkins_common` role.
 
 v 0.7.0 (30 June 2017)
 - Baseline

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v 0.7.1 (30 June 2017)
+v 0.7.1 (next release)
 - Updated Jenkins repo URL
 - Added ability to exclude changes to Jenkins plugins+configuration
 - Added configurable NTP server support

--- a/cinch/roles/jenkins_common/defaults/main.yml
+++ b/cinch/roles/jenkins_common/defaults/main.yml
@@ -12,3 +12,6 @@ jenkins_user_uid: 1000090000
 # (relative or full) to files containing separate public keys.
 # e.g.: ['mykey.pub', 'otherkey.pub']
 jenkins_authorized_keys: []
+# A list of additional packages that you wish to install on both masters and
+# slaves using the default package manager.
+extra_rpms: []

--- a/cinch/roles/jenkins_common/tasks/main.yml
+++ b/cinch/roles/jenkins_common/tasks/main.yml
@@ -16,6 +16,12 @@
   register: install_deps
   until: install_deps|success
 
+- name: install additional packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ extra_rpms }}"
+
 - name: upload common requirements file
   copy:
     src: requirements-common.txt

--- a/cinch/roles/jenkins_master/defaults/main.yml
+++ b/cinch/roles/jenkins_master/defaults/main.yml
@@ -44,7 +44,7 @@ session_timeout: 480
 jenkins_args:
 # A list of additional packages you wish to install using the default package
 # manager.
-additional_packages: []
+jmaster_extra_rpms: []
 
 # ############################################################################
 # Security settings - users, passwords, etc.

--- a/cinch/roles/jenkins_master/tasks/install.yml
+++ b/cinch/roles/jenkins_master/tasks/install.yml
@@ -38,7 +38,7 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items: "{{ additional_packages }}"
+  with_items: "{{ jmaster_extra_rpms }}"
 
 - name: install gcc_compat where necessary
   package:


### PR DESCRIPTION
These tools are all handy for diagnosing issues and the general
administration of both jenkins masters and slaves.

I'm honestly not sure if this is the best place for them, but do think that these packages are useful to have on both jenkins masters and slaves.

The vim install fails on f25, but so does the openjdk debuginfo line in the preceeding task, so again I'm not really sure what, if anything, to do about it.