### PR TITLE
Revert change from PR #139

### DIFF
--- a/cinch/roles/jenkins_common/tasks/main.yml
+++ b/cinch/roles/jenkins_common/tasks/main.yml
@@ -10,7 +10,6 @@
   with_items:
     - java-1.{{ java_version }}.0-openjdk
     - java-1.{{ java_version }}.0-openjdk-devel
-    - java-1.{{ java_version }}.0-openjdk-debuginfo
     - libselinux-python
     - openssh
   retries: 2


### PR DESCRIPTION
* Removed java-openjdk-debuginfo package, since some repo hosts don't
include the debug repositories.  We can revisit this in the future if
needed.