### PR TITLE
linchpin 1.0.2 compatibility

### DIFF
--- a/jjb/ci-jslave-project-sample.yaml
+++ b/jjb/ci-jslave-project-sample.yaml
@@ -63,10 +63,6 @@
           flatten: true
       - shell: |
             #!/bin/bash -ex
-            # work-around for output file naming issue with linchpin:
-            # https://github.com/CentOS-PaaS-SIG/linchpin/issues/294
-            ln -s ${{WORKSPACE}}/{topology_path}/${{PROVIDER}}/resources/cinch-test.output
-                ${{WORKSPACE}}/{topology_path}/${{PROVIDER}}/resources/cinch-test.output.yaml
             source "${{JENKINS_HOME}}/opt/cinch/bin/activate"
             cinchpin destroy -w {topology_path}/${{PROVIDER}}
 


### PR DESCRIPTION
* Removed work-around in JJB workflow template that's no longer needed
as of linchpin 1.0.2:

https://github.com/CentOS-PaaS-SIG/linchpin/pull/298