### PR TITLE
Removed packages formerly used for legacy provisioning tools

### DIFF
--- a/cinch/group_vars/cent6
+++ b/cinch/group_vars/cent6
@@ -5,8 +5,6 @@ _repositories:
     mirrorlist: "{{ fedora_mirrors }}repo=testing-epel6"
   - name: epel
     mirrorlist: "{{ fedora_mirrors }}repo=epel-6"
-  - name: cloud
-    baseurl: "{{ centos_mirrors }}/$releasever/cloud/$basearch/openstack-juno/"
 
 _download_repositories:
   - http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo

--- a/cinch/group_vars/cent7
+++ b/cinch/group_vars/cent7
@@ -5,8 +5,6 @@ _repositories:
     mirrorlist: "{{ fedora_mirrors }}repo=testing-epel7"
   - name: epel
     mirrorlist: "{{ fedora_mirrors }}repo=epel-7"
-  - name: cloud
-    baseurl: "{{ centos_mirrors }}/$releasever/cloud/$basearch/openstack-liberty/"
 
 _download_repositories:
   - https://fedorapeople.org/~semyers/jenkins-rpm/jenkins1651.repo

--- a/cinch/group_vars/rhel7
+++ b/cinch/group_vars/rhel7
@@ -19,9 +19,6 @@ all_repositories:
   epel:
     name: epel
     mirrorlist: "{{ fedora_mirrors }}repo=epel-7"
-  openstack:
-    name: openstack
-    baseurl: http://mirror.centos.org/centos/7/cloud/x86_64/openstack-mitaka/
   certificate:
     name: certificate-system
     baseurl: "{{ rhel_base }}/$basearch/certificate-system/9/os/"
@@ -43,7 +40,6 @@ jenkins_master_repositories:
   - "{{ all_repositories.optional }}"
   - "{{ all_repositories.debug }}"
   - "{{ all_repositories.epel }}"
-  - "{{ all_repositories.openstack }}"
   - "{{ all_repositories.certificate }}"
 
 jenkins_master_download_repositories:

--- a/cinch/roles/jenkins_common/files/requirements-common.txt
+++ b/cinch/roles/jenkins_common/files/requirements-common.txt
@@ -1,1 +1,0 @@
-# List common Python requirements to install here

--- a/cinch/roles/jenkins_common/tasks/main.yml
+++ b/cinch/roles/jenkins_common/tasks/main.yml
@@ -12,6 +12,9 @@
     - java-1.{{ java_version }}.0-openjdk-devel
     - libselinux-python
     - openssh
+    - gcc
+    - redhat-rpm-config
+    - git
   retries: 2
   register: install_deps
   until: install_deps|success

--- a/cinch/roles/jenkins_common/tasks/main.yml
+++ b/cinch/roles/jenkins_common/tasks/main.yml
@@ -22,11 +22,6 @@
     state: present
   with_items: "{{ extra_rpms }}"
 
-- name: upload common requirements file
-  copy:
-    src: requirements-common.txt
-    dest: /tmp/requirements-common.txt
-
 - name: create jenkins user
   user:
     name: "{{ jenkins_user }}"

--- a/cinch/roles/jenkins_master/tasks/install.yml
+++ b/cinch/roles/jenkins_master/tasks/install.yml
@@ -3,36 +3,16 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - git
-    - python-paramiko
-    - nss
-    - iptables
-    - iptables-services
     - "{{ jenkins_rpm }}"
-    - graphviz
-    - lftp
-    - gcc
-    - libffi-devel
-    - python-devel
-    - openssl-devel
-    - libxml2-devel
-    - libxslt-devel
-    - krb5-workstation
-    - python-futures
-    - python-six
-    - python-unittest2
-    - python-configobj
-    - python-nose
-    - cloud-utils
-    - python-glanceclient
-    - python-keystoneclient
-    - python-novaclient
-    - python-neutronclient
-    - wget
     - "{{ python_pip_package }}"
+    - libvirt-devel
     - python-virtualenv
-    - initscripts
-    - cloud-utils
+    - libyaml-devel
+    - openssl-devel
+    - libffi-devel
+    - gcc
+    - redhat-rpm-config
+    - ansible
 
 - name: install additional packages
   package:

--- a/cinch/roles/jenkins_master/tasks/install.yml
+++ b/cinch/roles/jenkins_master/tasks/install.yml
@@ -10,8 +10,6 @@
     - libyaml-devel
     - openssl-devel
     - libffi-devel
-    - gcc
-    - redhat-rpm-config
     - ansible
 
 - name: install additional packages

--- a/cinch/roles/jenkins_slave/defaults/main.yml
+++ b/cinch/roles/jenkins_slave/defaults/main.yml
@@ -31,20 +31,10 @@ jenkins_slave_password: ''
 # These are variables that you really should not override
 # unless you really know what you're doing
 jslave_rpm_deps:
-  - python-paramiko
   - git
   - gcc
-  - krb5-workstation
   - wget
   - python-pip
-  - python-unittest2
-  - python-pep8
-  # This package is not available in RHEL6
-  # TODO: fix
-  # - python-flake8
-  - python-futures
-  - python-devel
-  - nss
   - redhat-rpm-config
 
 jslave_extra_rpms: []

--- a/cinch/roles/jenkins_slave/defaults/main.yml
+++ b/cinch/roles/jenkins_slave/defaults/main.yml
@@ -31,10 +31,7 @@ jenkins_slave_password: ''
 # These are variables that you really should not override
 # unless you really know what you're doing
 jslave_rpm_deps:
-  - git
-  - gcc
   - wget
   - python-pip
-  - redhat-rpm-config
 
 jslave_extra_rpms: []

--- a/cinch/roles/jenkins_slave/tasks/main.yml
+++ b/cinch/roles/jenkins_slave/tasks/main.yml
@@ -8,19 +8,6 @@
     name: "{{ ( jslave_rpm_deps + jslave_extra_rpms ) | join(',') }}"
     state: present
 
-- name: install pip packages
-  pip:
-    requirements: /tmp/requirements-common.txt
-    state: present
-
-- name: install additional pip packages
-  pip:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - ansible==1.8.4
-    - nose
-
 - name: add host to hosts file
   lineinfile:
     line: "{{ ansible_ssh_host }} {{ inventory_hostname }}.localdomain"


### PR DESCRIPTION
* Removed RHOS repos from group_vars

* Removed legacy Python requirements.txt file

* Removed a large number of RPM packages from the jenkins_master role
that are no longer needed and added dependencies needed by cinch for
Jenkins slave provisioning

* Removed various QE test tools from the jenkins_slave role.  These
types of packages should be provided by the user via Ansible variables
instead of being included in the role by default.