### PR TITLE
Refine thinBackup plugin configuration defaults

### DIFF
--- a/cinch/playbooks/jenkins_backup.yml
+++ b/cinch/playbooks/jenkins_backup.yml
@@ -29,7 +29,7 @@
       diff_schedule: H 0 * * *
       max_sets: 2
       exclude: ''
-      wait_for_idle: true
+      wait_for_idle: false
       quiet_mode_timeout: 480
       build_results: false
       user_contents: true

--- a/cinch/roles/jenkins_master/templates/init_backup.groovy
+++ b/cinch/roles/jenkins_master/templates/init_backup.groovy
@@ -11,15 +11,15 @@ String backupPath = "{{ jenkins_backup.directory|default('/jenkins_backup/.backu
 String fullBackupSchedule = "{{ jenkins_backup.full_schedule|default('H 0 * * 0') }}";
 String diffBackupSchedule = "{{ jenkins_backup.diff_schedule|default('H 0 * * *') }}";
 String excludedFiles = "{{ jenkins_backup.exclude|default('') }}";
-def maxSets = {{ jenkins_backup.max_sets|default(4) }};
+def maxSets = {{ jenkins_backup.max_sets|default(2) }};
 def waitForIdle = {{ jenkins_backup.wait_for_idle|default(false)|to_json }};
-def forceQuietModeTimeout = {{ jenkins_backup.quiet_mode_timeout|default(120)|to_json }};
+def forceQuietModeTimeout = {{ jenkins_backup.quiet_mode_timeout|default(480)|to_json }};
 def backupBuildResults = {{ jenkins_backup.build_results|default(false)|to_json }};
-def backupUserContents = {{ jenkins_backup.user_contents|default(false)|to_json }};
-def cleanupDiff = {{ jenkins_backup.cleanup_diffs|default(false)|to_json }};
-def backupNextBuildNumber = {{ jenkins_backup.next_build_number|default(false)|to_json }};
+def backupUserContents = {{ jenkins_backup.user_contents|default(true)|to_json }};
+def cleanupDiff = {{ jenkins_backup.cleanup_diffs|default(true)|to_json }};
+def backupNextBuildNumber = {{ jenkins_backup.next_build_number|default(true)|to_json }};
 def moveOldBackupsToZipFile = {{ jenkins_backup.move_to_zip|default(false)|to_json }};
-def backupPluginArchives = {{ jenkins_backup.plugin_archives|default(false)|to_json }};
+def backupPluginArchives = {{ jenkins_backup.plugin_archives|default(true)|to_json }};
 
 def void changed(String field, def value) {
 	changes = true;


### PR DESCRIPTION
* wait_for_idle is problematic and is now disabled by default, see this
for more details:

https://github.com/RedHatQE/cinch/pull/138#discussion_r133901263

* Other defaults have been changed based on successful experience in a
production environment, but obviously these settings are all highly
environment-specific and should be adjusted accordingly.

* Note that this automation exists in the source tree but is entirely
disabled given that thinBackup has many limitations and users may
implement other, more comprehensive backup solutions at another level
such as on the underlying storage device.