### PR TITLE
Compatibility for upgrade to Jenkins 2.x

### DIFF
--- a/cinch/library/jenkins_user_api.py
+++ b/cinch/library/jenkins_user_api.py
@@ -34,6 +34,7 @@ def main():
             'cli_jar': {'default':
                         '/var/cache/jenkins/war/WEB-INF/jenkins-cli.jar'},
             'jenkins_url': {'default': 'http://localhost:8080'},
+            'remoting': {'required': True, 'type': 'bool'},
             'java_command': {'type': 'str', 'default': '/usr/bin/java'}
         }
     )
@@ -46,13 +47,17 @@ def main():
     groovy = NamedTemporaryFile(delete=False)
     groovy.write(MYFILE.format(args.user))
     groovy.close()
-    process = [args.java_command,
-               '-jar',
-               args.cli_jar,
-               '-s',
-               args.jenkins_url,
-               'groovy',
-               groovy.name]
+    process_named_args = [args.java_command,
+                          '-jar',
+                          args.cli_jar,
+                          '-s',
+                          args.jenkins_url]
+    # Append -remoting argument to named argument list depending on the version
+    # of Jenkins
+    if args.remoting:
+        process_named_args.append('-remoting')
+    process_positional_args = ['groovy', groovy.name]
+    process = process_named_args + process_positional_args
     # The groovy code simply prints out the value of the API key, so we want
     # to be able to capture that output
     p = subprocess.Popen(process,

--- a/cinch/roles/jenkins_master/defaults/main.yml
+++ b/cinch/roles/jenkins_master/defaults/main.yml
@@ -21,6 +21,11 @@ https_enabled: false
 # to construct the name of the RPM below as well as update center URLS, so this
 # must include the complete "x.y.z" version, e.g. 1.651.3.
 jenkins_version: "1.651.3"
+# Temporarily remove the jenkins package from the package mananger pinning
+# configuration to allow upgrades of the jenkins package.  Note that other
+# packages blacklisted by the upgrade_blacklist variable will remain pinned via
+# the package manager configuration.
+jenkins_upgrade: false
 # Update center version based on jenkins_version, update center does not use
 # "z" bit of the version, for example 1.651.3 becomes 1.651. This split
 # incantation strips the '.z' version off of jenkins_version.

--- a/cinch/roles/jenkins_master/tasks/ensure_up.yml
+++ b/cinch/roles/jenkins_master/tasks/ensure_up.yml
@@ -32,9 +32,18 @@
     'status' in jenkins_status and
     (jenkins_status['status'] == 200 or jenkins_status['status'] == 401)
 
+# Newer Jenkins versions require the -remoting flag to allow the Jenkins CLI to
+# be available in the way that we use it currently. The 'X-Jenkins' response
+# header gives us the current version.
+# https://jenkins.io/doc/book/managing/cli/#remoting-connection-mode
+- name: check Jenkins version for -remoting flag
+  set_fact:
+    jenkins_cli_remoting: "{{ jenkins_status.x_jenkins | version_compare('2.46.2', '>=') }}"
+
 - name: get user api key
   jenkins_user_api:
     user: "{{ jenkins_admin.nickname }}"
+    remoting: "{{ jenkins_cli_remoting }}"
   register: jenkins_admin_api_key
   become: true
   become_user: "{{ jenkins_user }}"

--- a/cinch/roles/jenkins_master/tasks/install.yml
+++ b/cinch/roles/jenkins_master/tasks/install.yml
@@ -1,3 +1,11 @@
+- name: unpin jenkins package for version upgrades
+  lineinfile:
+    dest: "{{ version_pin_file }}"
+    state: present
+    regexp: "^exclude=.*"
+    line: "exclude={{ upgrade_blacklist | difference(['jenkins']) | join(' ') }}"
+  when: jenkins_upgrade
+
 - name: install necessary RPM files
   package:
     name: "{{ item }}"


### PR DESCRIPTION
* Allow upgrades via unpinning the 'jenkins' package #142

* Added conditional addition of the -remoting flag for the jenkins_cli
that's required for Jenkins versions >= 2.46.2