### PR TITLE
Add service restart when upgrading

### DIFF
--- a/cinch/roles/jenkins_master/handlers/main.yml
+++ b/cinch/roles/jenkins_master/handlers/main.yml
@@ -11,6 +11,12 @@
     name: jenkins
     state: restarted
 
+- name: restart Jenkins during upgrade
+  service:
+    name: jenkins
+    state: restarted
+  when: jenkins_upgrade
+
 # Reload firewalld by running command, since the firewalld module doesn't
 # support the functionality to reload rules.
 - name: reload firewalld

--- a/cinch/roles/jenkins_master/tasks/install.yml
+++ b/cinch/roles/jenkins_master/tasks/install.yml
@@ -19,6 +19,7 @@
     - openssl-devel
     - libffi-devel
     - ansible
+  notify: restart Jenkins during upgrade
 
 - name: install additional packages
   package:


### PR DESCRIPTION
The Jenkins service should be restarted if the RPM installer changes
during the Jenkins upgrade cycle. But not if the cycle is installing
a new Jenkins system.