### PR TITLE
removed ansible RPM package dependency - cinch generally runs via a v…

### DIFF
--- a/cinch/roles/jenkins_master/tasks/install.yml
+++ b/cinch/roles/jenkins_master/tasks/install.yml
@@ -18,7 +18,6 @@
     - libyaml-devel
     - openssl-devel
     - libffi-devel
-    - ansible
 
 - name: install additional packages
   package:


### PR DESCRIPTION
…irtualenv where ansible is installed