### PR TITLE
Removed ansible RPM package dependency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v 0.8.1 (11 Sep 2017)
+- Removed ansible RPM package from jenkins_master role
+
 v 0.8.0 (6 Sep 2017)
 - Added support for upgrading to Jenkins 2 from Jenkins 1
 - Added support for installing pinned plugins from multiple update centers

--- a/cinch/roles/jenkins_master/tasks/install.yml
+++ b/cinch/roles/jenkins_master/tasks/install.yml
@@ -18,7 +18,6 @@
     - libyaml-devel
     - openssl-devel
     - libffi-devel
-    - ansible
   notify: restart Jenkins during upgrade
 
 - name: install additional packages

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='cinch',
-    version='0.8.0',
+    version='0.8.1',
     description='Cinch continuous integration setup',
     long_description=description,
     url='https://github.com/RedHatQE/cinch',


### PR DESCRIPTION
cinch generally runs via a virtualenv where ansible is installed, so the
RPM package is not necessary.