### PR TITLE
Omit jenkins_user_password by default #169

### DIFF
--- a/cinch/group_vars/all
+++ b/cinch/group_vars/all
@@ -15,7 +15,10 @@ python_pip_package: python2-pip
 # Default user and directory to place the Jenkins files in
 jenkins_user: jenkins
 jenkins_user_home: /var/lib/jenkins
-jenkins_user_password: changeme
+# Optionally set a password for the jenkins user.  In most cases a null
+# password is preferred, which will be set if this variable is left undefined.
+#jenkins_user_password: changeme
+
 # The home directory for the Jenkins user, and the base directory for Jenkins
 # files and jobs
 jenkins_home: /var/lib/jenkins

--- a/cinch/roles/jenkins_common/tasks/main.yml
+++ b/cinch/roles/jenkins_common/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: create jenkins user
   user:
     name: "{{ jenkins_user }}"
-    password: "{{ jenkins_user_password }}"
+    password: "{{ jenkins_user_password | default(omit) }}"
     home: "{{ jenkins_user_home }}"
     shell: /bin/bash
     uid: "{{ jenkins_user_uid | default(omit) }}"

--- a/docs/source/users.rst
+++ b/docs/source/users.rst
@@ -179,11 +179,7 @@ Create a layout file by saving the following example template as
             - jenkins_slave
 
 Create an Ansible group_vars file by saving the following example template as
-**/path/to/workdir/inventories/group_vars/all** and edit to taste.  For the
-**jenkins_user_password** variable, please use the `Ansible documentation
-<https://docs.ansible.com/ansible/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module>`_
-to generate a suitable password hash.  **For security in production
-environments, DO NOT copy the existing hash from this example.** ::
+**/path/to/workdir/inventories/group_vars/all** and edit to taste.::
 
     ---
     ansible_user: root
@@ -195,7 +191,6 @@ environments, DO NOT copy the existing hash from this example.** ::
       - https://example.com/ca2.crt
     # Base URL for repository mirror
     rhel_base: http://example.com/content/dist/rhel/server/7/7Server
-    jenkins_user_password: '$6$rounds=656000$YQKMBktZ/Gaggxf0$KC7xhatWzdDJyvCDo7htomtiSsvd2MWN87RB3TsAbq1Nmwddy/z2Et8kQi1/tZkHjfD2vG1r7W2R9rjpaA1C5/'
     jenkins_master_url: 'http://jenkins.example.com' # URL to Jenkins master for the slave to connect to
     jslave_name: 'cinch-slave'
     jslave_label: 'cinch-slave'


### PR DESCRIPTION
In most cases setting this password is not desirable, so it should be
null by default.