### PR TITLE
Updates in service of upgradeability

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+v 0.8.3 (next)
+- Stop Jenkins process before upgrading
+- Avoid modifying Beaker during upgrades
+- Make jenkins user passwords optional, to avoid unnecessarily changing them
+  on existing systems
+
 v 0.8.2 (12 Sep 2017)
 - Added jenkins_cli_shell_user and jenkins_cli_shell_user_home, to allow better
   configuration of where to configure Jenkins CLI users' SSH keys

--- a/cinch/roles/jenkins_master_stop/tasks/main.yml
+++ b/cinch/roles/jenkins_master_stop/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: stop the Jenkins process
+  service:
+    name: jenkins
+    state: stopped
+  become: true

--- a/cinch/site.yml
+++ b/cinch/site.yml
@@ -4,6 +4,12 @@
   roles:
     - check_ssh
 
+- name: stop Jenkins process when upgrading
+  hosts: jenkins_master
+  roles:
+    - role: jenkins_master_stop
+      when: jenkins_upgrade is defined and jenkins_upgrade
+
 - name: upload files before
   hosts: all
   roles:
@@ -34,7 +40,8 @@
   become: true
   hosts: jenkins_master
   roles:
-    - beaker-client
+    - role: beaker-client
+      when: jenkins_upgrade is not defined or not jenkins_upgrade
     - role: nginx
       when: ansible_connection != 'docker'
     - jenkins_master


### PR DESCRIPTION
The Jenkins service should be stopped before doing upgrades

The Beaker client should be skipped over if a system is already
configured, as there are deficiencies in that role's detection of
current configurations

Fixes: #170
Fixes: #171