### PR TITLE
Extra repositories

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v 0.10.0 (NEXT)
+- Update default Jenkins version to 2.60
+- Update plugins list to 2.60-friendly list
+- Add support for extra_repositories in repo list
+
 v 0.9.0 (16 Nov 2017)
 - IMPORTANT - The 'cinchpin' command has been REMOVED for linchpin 1.0.4
   compatibility.  The new 'teardown' command replaces Jenkins slave

--- a/cinch/roles/repositories/defaults/main.yml
+++ b/cinch/roles/repositories/defaults/main.yml
@@ -1,5 +1,11 @@
 # Override with an array of objects like you would find in playbook/group_vars/rhel7
-# if you want a different set of repositories than this package installs by default
+# if you want a different set of repositories than this package installs by default.
+# It is not recommended that you touch the "repositories" variable in your
+# variables, as that value is set to include repositories that are necessary for
+# master and slave software installation. Extra repositories is unused by this
+# software and is designed to be overridden by the user with any extra repositories
+# they want added to the host.
+extra_repositories: []
 repositories: []
 
 # Override with an array of strings that are URLs to repository files, if you want

--- a/cinch/roles/repositories/defaults/main.yml
+++ b/cinch/roles/repositories/defaults/main.yml
@@ -2,7 +2,7 @@
 # if you want a different set of repositories than this package installs by default.
 # It is not recommended that you touch the "repositories" variable in your
 # variables, as that value is set to include repositories that are necessary for
-# master and slave software installation. Extra repositories is unused by this
+# master and slave software installation. extra_repositories is unused by this
 # software and is designed to be overridden by the user with any extra repositories
 # they want added to the host.
 extra_repositories: []

--- a/cinch/roles/repositories/tasks/main.yml
+++ b/cinch/roles/repositories/tasks/main.yml
@@ -1,5 +1,5 @@
 - include: repositories.yml
-  with_items: "{{ repositories }}"
+  with_items: "{{ repositories + extra_repositories }}"
 
 - include: repository_download.yml
   with_items: "{{ download_repositories }}"

--- a/vagrant/master_rhel7/README
+++ b/vagrant/master_rhel7/README
@@ -1,8 +1,8 @@
 To run this box, you will need to find and add a Vagrant box for RHEL7. Currently the
-version supported is RHEL 7.2. If you have access to provided RHEL7.2 Vagrant box file,
+version supported is RHEL 7.4. If you have access to provided RHEL7.4 Vagrant box file,
 you can add it to your local system with a command like
 
-```vagrant box add --name rhel7.2 http://somewhere.com/vagrant/box/files/rhel7.2.box```
+```vagrant box add --name rhel7.4 http://somewhere.com/vagrant/box/files/rhel7.4.box```
 
 Since RHEL7 is under license, these images are probably not readily available to public
 infrastructure, but this Vagrantfile is provided in the interest of testing and for those

--- a/vagrant/master_rhel7/Vagrantfile
+++ b/vagrant/master_rhel7/Vagrantfile
@@ -1,13 +1,13 @@
 require "../shared.rb"
 
 Vagrant.configure("2") do |config|
-    vm(config, "master", "rhel7.2") do |ansible|
+    vm(config, "master", "rhel7.4") do |ansible|
          ansible.groups = {
             "jenkins_master" => ["master"],
             "rhel7" => ["master"],
             "repositories" => ["master"],
             "jenkins_master:vars" => {
-                "rhel_base" => "http://example.com/content/dist/rhel/server/7/7.2"
+                "rhel_base" => "http://example.com/content/dist/rhel/server/7/7.4"
             }
         }
     end

--- a/vagrant/shared.rb
+++ b/vagrant/shared.rb
@@ -26,6 +26,8 @@ def get_image(base_box)
         return 'rhel-7.2-server-x86_64-updated'
     elsif base_box == 'rhel7.3'
         return 'rhel-7.3-server-x86_64-updated'
+    elsif base_box == 'rhel7.4'
+        return 'rhel-7.4-server-x86_64-updated'
     elsif base_box == 'rhel6'
         return 'rhel-6.9-server-x86_64-updated'
     end

--- a/vagrant/slave_rhel7/README
+++ b/vagrant/slave_rhel7/README
@@ -1,11 +1,11 @@
-This Vagrantfile spins up a jenkins slave only. There is no master
-that it is attached to. The slave will be based on a rhel7.2 box.
+This file spins up a pair of Jenkins master and slave instances
+running RHEL7.  They will be based on a rhel7.4 box.
 Since these boxes are not available to the general public, you
 will need to either update the Vagrantfile with the name and URL
 of your accessible base box or you will need to import the box.
 Importing can be done with the command
 
-``vagrant box add --name rhel7.2 <url to box>``
+``vagrant box add --name rhel7.4 <url to box>``
 
 You will still need to modify the Vagrantfile to update the value
 of the rhel_base variable to point to the base directory of your

--- a/vagrant/slave_rhel7/Vagrantfile
+++ b/vagrant/slave_rhel7/Vagrantfile
@@ -1,16 +1,18 @@
 require "../shared.rb"
 
 Vagrant.configure("2") do |config|
-    vm(config, "slave", "rhel7.2") do |ansible|
+    vm(config, "master", "rhel7.4")
+    vm(config, "slave", "rhel7.4") do |ansible|
         ansible.groups = {
+            "jenkins_master" => ["master"],
             "jenkins_slave" => ["slave"],
-            "rhel7" => ["slave"],
+            "rhel7" => ["master", "slave"],
+            "repositories" => ["master", "slave"],
             "jenkins_slave:vars" => {
-                "jenkins_master_url" => "http://10.8.172.6",
-                "jenkins_user_password" => "threeblindmice"
+                "jenkins_master_url" => "http://{{ hostvars['master']['ansible_default_ipv4']['address'] }}"
             },
             "rhel7:vars" => {
-                "rhel_base" => "http://example.com/content/dist/rhel/server/7/7.2"
+                "rhel_base" => "http://example.com/content/dist/rhel/server/7/7Server"
             }
         }
     end


### PR DESCRIPTION
Adds support for the extra repositories, so users do not have to override the in-build repositories list in order to support their own custom repos as well.