### PR TITLE
Allow for spaces in SSH key file path in the check_ssh role (#187)

### DIFF
--- a/cinch/roles/check_ssh/tasks/main.yml
+++ b/cinch/roles/check_ssh/tasks/main.yml
@@ -8,7 +8,7 @@
     set_fact:
       check_ssh_cmd: >-
         ansible --ssh-extra-args='-o StrictHostKeyChecking=no'
-        -i {{ inventory_dir }}/{{ (inventory_file | string | default('')) | basename }}
+        -i '{{ inventory_dir }}/{{ (inventory_file | string | default('')) | basename }}'
         {{ host }} -m ping
 
   - name: check for SSH connectivity and authentication


### PR DESCRIPTION
* Added single quotes to the SSH key file path so that the shell can find the
SSH key file if the path contains a space.