### PR TITLE
Clarified documentation for CLI and Ansible vars (#195)

### DIFF
--- a/cinch/bin/entry_point.py
+++ b/cinch/bin/entry_point.py
@@ -7,15 +7,16 @@ from wrappers import call_ansible
 import sys
 
 
-def cinch_generic(playbook):
+def cinch_generic(playbook, help_description):
     # Parse the command line arguments
-    parser = ArgumentParser(description='A wrapper around Cinch for the most '
-                            'common use case')
+    parser = ArgumentParser(description='A CLI wrapper for ansible-playbook '
+                            'to run cinch playbooks.  ' + help_description)
     # The inventory file that the user provides which will get passed along to
     # Ansible for its consumption
-    parser.add_argument('inventory')
+    parser.add_argument('inventory', help='Ansible inventory file (required)')
     # All remaining arguments are passed through, untouched, to Ansible
-    parser.add_argument('args', nargs=REMAINDER)
+    parser.add_argument('args', nargs=REMAINDER, help='extra args to '
+                        'pass to the ansible-playbook command (optional)')
     args = parser.parse_args()
     if len(args.inventory) > 0:
         if args.inventory[0] == '/':
@@ -40,7 +41,9 @@ def cinch():
     if an unknown error occurs. If ansible-playbook exits with an error code,
     this executable will exit with the same code.
     """
-    cinch_generic('site.yml')
+    help_description = '''This command runs the 'site.yml' playbook to
+                          configure a Jenkins master or slave.'''
+    cinch_generic('site.yml', help_description)
 
 
 def teardown():
@@ -52,7 +55,9 @@ def teardown():
     an unknown error occurs. If ansible-playbook exits with an error code, this
     executable will exit with the same code.
     """
-    cinch_generic('teardown.yml')
+    help_description = '''This command runs the 'teardown.yml' playbook to
+                          disconnect a Jenkins slave.'''
+    cinch_generic('teardown.yml', help_description)
 
 
 if __name__ == '__main__':

--- a/docs/source/user_files.rst
+++ b/docs/source/user_files.rst
@@ -4,7 +4,7 @@ User Files
 Motivation
 ----------
 
-Anyone using Cinch to provision either a Jenkins master os slave may have the
+Anyone using Cinch to provision either a Jenkins master or slave may have the
 need to perform configuration to the system that exceeds the ability of Cinch to
 reasonably include support for within these playbooks. These could cover nearly
 any aspect of system administration, monitoring, configuration, and setup. For

--- a/docs/source/users.rst
+++ b/docs/source/users.rst
@@ -205,10 +205,15 @@ configured. Use normal methods for setting **group\_vars** and **host\_vars**
 within the inventory or its associated folders that suits your own needs and
 preferences.
 
-While most default settings should be functional, there are lots of options
-configured in the various **default/main.yml** files within the various roles
-folders. Check in those files for more details on specific options that can be
-set and a description of what they each mean.
+.. seealso:: While most default settings should be functional, there are lots
+             of options configured in the various **default/main.yml** files
+             within the various roles folders. Check in those files for more
+             details on specific options that can be set and a description of
+             what they each mean. *These files are heavily commented, and serve
+             as the best source of documentation for the way that cinch
+             configures a system.  If you feel the need to modify cinch
+             playbooks directly, first check to see if the behavior you want is
+             configurable via the provided Ansible variables.*
 
 See a few examples of such in either the **inventory/** folder or inside of the
 various **vagrant/** subfolders where known good working environments are
@@ -224,9 +229,22 @@ environment as easy as a single command.
 The cinch project can be used as a standard Ansible project, by running
 **ansible-playbook** and calling **site.yml** for Jenkins master or slave
 configuration and **teardown.yml** for removing a Jenkins slave from a Jenkins
-master. For convenience, we also provide CLI wrappers for these tasks, with the
-**cinch** command running **site.yml** and the **teardown** command running
-**teardown.yml**.
+master.
+
+For convenience, we also provide CLI wrappers for these tasks.  These wrappers
+simplify the task of finding and running the desired cinch playbooks for
+configuration or teardown, and also can optionally pass through any additional
+CLI arguments to the 'ansible-playbook' command that you may need.
+
+The following commands are available:
+
+- ``cinch`` - runs the **site.yml** playbook to configure a Jenkins master or
+  slave
+- ``teardown`` - runs the **teardown.yml** playbook to disconnect a Jenkins
+  slave
+
+Use the ``-h`` or ``--help`` arguments for the CLI wrappers to get further
+info.
 
 
 Support

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from cinch.bin.wrappers import call_ansible
+from cinch.bin.wrappers import call_ansible, command_handler
 
 
 class CinchCLI(unittest.TestCase):
@@ -18,3 +18,8 @@ class CinchCLI(unittest.TestCase):
     def test_exit_code_one(self):
         # inventory and playbook files that do not exist
         self.assertEqual(call_ansible('junk.ini', 'junk.yml'), 1)
+
+    def test_exit_code_255(self):
+        # invalid data given to plumbum which should return exit code 255
+        self.assertEqual(command_handler('invalid_command',
+                                         'invalid_arg'), 255)


### PR DESCRIPTION
* Added more detailed --help info for the 'cinch' and 'teardown'
commands

* Updated Sphinx docs to help users find the CLI capabilities more
easily

* Updated Sphinx docs to highlight how important the provided Ansible
default vars are for understanding and customizing behavior.