### PR TITLE
Fix groovy script so check_mode truly performs no modifications to the system

### DIFF
--- a/cinch/roles/jenkins_master/templates/basic_security.groovy
+++ b/cinch/roles/jenkins_master/templates/basic_security.groovy
@@ -1,22 +1,22 @@
 import hudson.security.*;
 
+def check_mode = {{ ansible_check_mode|to_json }};
+
 boolean changed = false;
 def jenkins = jenkins.model.Jenkins.getActiveInstance();
 AuthorizationStrategy strategy = jenkins.getAuthorizationStrategy();
 if ( ! ( strategy instanceof AuthorizationStrategy.Unsecured ) ) {
 	strategy = new AuthorizationStrategy.Unsecured();
-	jenkins.setAuthorizationStrategy(strategy);
-	println "CHANGED: Updated strategy to be unsecred."
+	if ( !check_mode ) jenkins.setAuthorizationStrategy(strategy);
+	println "CHANGED: Updated strategy to be unsecured."
 	changed = true;
 }
 if ( ! (jenkins.getSecurityRealm() instanceof HudsonPrivateSecurityRealm) ) {
 	HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(allowsSignup=false);
-	jenkins.setSecurityRealm(realm);
+	if ( !check_mode ) jenkins.setSecurityRealm(realm);
 	println "CHANGED: Updated security realm to be private realm"
 	changed = true;
 }
-
-def check_mode = {{ ansible_check_mode|to_json }};
 
 if ( !check_mode && changed )
 	jenkins.save();

--- a/cinch/roles/jenkins_master/templates/init_backup.groovy
+++ b/cinch/roles/jenkins_master/templates/init_backup.groovy
@@ -7,6 +7,7 @@ def jenkins = Jenkins.getActiveInstance();
 def thinbackup = ThinBackupPluginImpl.getInstance();
 boolean changes = false;
 
+def check_mode = {{ ansible_check_mode|to_json }};
 String backupPath = "{{ jenkins_backup.directory|default('/jenkins_backup/.backups') }}";
 String fullBackupSchedule = "{{ jenkins_backup.full_schedule|default('H 0 * * 0') }}";
 String diffBackupSchedule = "{{ jenkins_backup.diff_schedule|default('H 0 * * *') }}";
@@ -27,58 +28,58 @@ def void changed(String field, def value) {
 }
 
 if( !thinbackup.getBackupPath().equals(backupPath) ){
-	thinbackup.setBackupPath(backupPath);
+	if( !check_mode ) thinbackup.setBackupPath(backupPath);
 	changed("backup path", backupPath);
 }
 if( !thinbackup.getFullBackupSchedule().equals(fullBackupSchedule) ) {
-	thinbackup.setFullBackupSchedule(fullBackupSchedule);
+	if( !check_mode ) thinbackup.setFullBackupSchedule(fullBackupSchedule);
 	changed("full backup schedule", fullBackupSchedule);
 }
 if( !thinbackup.getDiffBackupSchedule().equals(diffBackupSchedule) ){
-	thinbackup.setDiffBackupSchedule(diffBackupSchedule);
+	if( !check_mode ) thinbackup.setDiffBackupSchedule(diffBackupSchedule);
 	changed("diff backup schedule", diffBackupSchedule);
 }
 if( thinbackup.getNrMaxStoredFull() != maxSets ) {
-	thinbackup.setNrMaxStoredFull(maxSets);
+	if( !check_mode ) thinbackup.setNrMaxStoredFull(maxSets);
 	changed("max number of backups stored", maxSets);
 }
 if( !thinbackup.getExcludedFilesRegex().equals(excludedFiles) ) {
-	thinbackup.setExcludedFilesRegex(excludedFiles);
+	if( !check_mode ) thinbackup.setExcludedFilesRegex(excludedFiles);
 	changed("excluded files", excludedFiles);
 }
 if( thinbackup.isWaitForIdle() != waitForIdle ) {
-	thinbackup.setWaitForIdle(waitForIdle);
+	if( !check_mode ) thinbackup.setWaitForIdle(waitForIdle);
 	changed("wait for idle", waitForIdle);
 }
 if( thinbackup.getForceQuietModeTimeout() != forceQuietModeTimeout ) {
-	thinbackup.setForceQuietModeTimeout(forceQuietModeTimeout);
+	if( !check_mode ) thinbackup.setForceQuietModeTimeout(forceQuietModeTimeout);
 	changed("force quiet mode timeout", forceQuietModeTimeout);
 }
 if( thinbackup.isBackupBuildResults() != backupBuildResults ) {
-	thinbackup.setBackupBuildResults(backupBuildResults);
+	if( !check_mode ) thinbackup.setBackupBuildResults(backupBuildResults);
 	changed("backup build results", backupBuildResults);
 }
 if( thinbackup.isBackupUserContents() != backupUserContents ) {
-	thinbackup.setBackupUserContents(backupUserContents);
+	if( !check_mode ) thinbackup.setBackupUserContents(backupUserContents);
 	changed("backup user contents", backupUserContents);
 }
 if( thinbackup.isCleanupDiff() != cleanupDiff ) {
-	thinbackup.setCleanupDiff(cleanupDiff);
+	if( !check_mode ) thinbackup.setCleanupDiff(cleanupDiff);
 	changed("cleanup diffs", cleanupDiff);
 }
 if( thinbackup.isBackupNextBuildNumber() != backupNextBuildNumber ) {
-	thinbackup.setBackupNextBuildNumber(backupNextBuildNumber);
+	if( !check_mode ) thinbackup.setBackupNextBuildNumber(backupNextBuildNumber);
 	changed("backup next build number", backupNextBuildNumber);
 }
 if( thinbackup.isMoveOldBackupsToZipFile() != moveOldBackupsToZipFile ) {
-	thinbackup.setMoveOldBackupsToZipFile(moveOldBackupsToZipFile);
+	if( !check_mode ) thinbackup.setMoveOldBackupsToZipFile(moveOldBackupsToZipFile);
 	changed("move old backups to zip", moveOldBackupsToZipFile);
 }
 
 if( thinbackup.isBackupPluginArchives() != backupPluginArchives ) {
-	thinbackup.setBackupPluginArchives(backupPluginArchives);
+	if( !check_mode ) thinbackup.setBackupPluginArchives(backupPluginArchives);
 	changed("backup plugin archives", backupPluginArchives);
 }
 
-if( changes && !checkMode )
+if( changes && !check_mode )
 	thinbackup.save();

--- a/cinch/roles/jenkins_master/templates/jenkins_root_url.groovy
+++ b/cinch/roles/jenkins_master/templates/jenkins_root_url.groovy
@@ -8,7 +8,7 @@ def check_mode = {{ ansible_check_mode|to_json }};
 String oldUrl = StringUtils.stripEnd(jlc.getUrl(), "/");
 
 if( !oldUrl.equals(newUrl) ) {
-	jlc.setUrl(newUrl);
+	if ( !check_mode ) jlc.setUrl(newUrl);
 	print "CHANGED: Updated base URL to " + newUrl;
 	changed = true;
 }

--- a/cinch/roles/jenkins_master/templates/set_slaveport.groovy
+++ b/cinch/roles/jenkins_master/templates/set_slaveport.groovy
@@ -12,7 +12,7 @@ def change_msg = "CHANGED: slave agent port from " + slave_agent_port +
     " to " + jenkins_slave_agent_port
 
 if (slave_agent_port != jenkins_slave_agent_port) {
-    if (check_mode == true) {
+    if (check_mode) {
         println change_msg
     } else {
         jenkins.setSlaveAgentPort(jenkins_slave_agent_port)

--- a/cinch/roles/jenkins_master/templates/set_usebrowser.groovy
+++ b/cinch/roles/jenkins_master/templates/set_usebrowser.groovy
@@ -15,7 +15,7 @@ def change_msg = "CHANGED: setUseBrowser from " + usebrowser + " to " +
     jenkins_usebrowser
 
 if (usebrowser != jenkins_usebrowser) {
-    if (check_mode == true) {
+    if (check_mode) {
         println change_msg
     } else {
         ds.setUseBrowser(jenkins_usebrowser)

--- a/cinch/roles/jenkins_master/templates/setenvvars.groovy
+++ b/cinch/roles/jenkins_master/templates/setenvvars.groovy
@@ -11,12 +11,16 @@ def check_mode = {{ ansible_check_mode|to_json }};
 
 {% for var in jenkins_envvars %}
 if (isEmptyNode) {
-	j.globalNodeProperties.replaceBy([new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("{{ var.key }}", "{{ var.value }}"))]);
-	isEmptyNode = false;
-} else {
-	j.globalNodeProperties.get(0).getEnvVars().put("{{ var.key }}", "{{ var.value }}");
+  if ( !check_mode )
+    j.globalNodeProperties.replaceBy([new EnvironmentVariablesNodeProperty()]);
+  isEmptyNode = false;
 }
+
+if ( !check_mode )
+  j.globalNodeProperties.get(0).getEnvVars().put("{{ var.key }}", "{{ var.value }}");
+println "Adding environment variable {{ var.key }}={{ var.value }}";
+
 {% endfor %}
 
 if ( !check_mode )
-	j.save();
+  j.save();


### PR DESCRIPTION
Most of the groovy scripts was implemented in a way they performed modifications to Jenkins model but not persisted them to disk. This fixes groovy scripts implementing `check_mode` so it does not touch Jenkins model at all.