### PR TITLE
Add support for jenkins_extra_plugins

### DIFF
--- a/cinch/roles/jenkins_master/defaults/main.yml
+++ b/cinch/roles/jenkins_master/defaults/main.yml
@@ -48,6 +48,8 @@ jenkins_plugins:
 #jenkins_plugins:
 #  - plugins: "{{ lookup('url', 'http://example.com/default.txt').split(',') }}"
 #    url: "{{ omit }}" # Omit in order to use default update center
+# Extra plugins to install, specified by the user with the same format as jenkins_plugins
+jenkins_extra_plugins: []
 # Bundled plugins are ones that are included by default with Jenkins. The process
 # of pinning a bundled plugin tells Jenkins to not overwrite the correct version
 # of plugin with an included version during a Jenkins upgrade but rather use the

--- a/cinch/roles/jenkins_master/tasks/plugins.yml
+++ b/cinch/roles/jenkins_master/tasks/plugins.yml
@@ -46,7 +46,7 @@
   retries: 3
   until: not plugin_install|failed
   with_subelements:
-    - "{{ jenkins_plugins }}"
+    - "{{ jenkins_plugins + jenkins_extra_plugins }}"
     - plugins
   notify: restart Jenkins
 


### PR DESCRIPTION
I was attempting to use the functionality documented in
http://redhatqe-cinch.readthedocs.io/en/latest/config.html#jenkins-plugins,
specifically the "jenkins_extra_plugins" var, and it didn't appear to be
supported.