### PR TITLE
nginx: increase upload size limit to allow Jenkins UI plugin uploads

### DIFF
--- a/cinch/roles/nginx/defaults/main.yml
+++ b/cinch/roles/nginx/defaults/main.yml
@@ -8,6 +8,9 @@ service_name: "{{ hostvars[inventory_hostname]['ansible_host'] | default(invento
 nginx_error_level: "warn"
 nginx_worker_processes: 1
 nginx_gzip_status: "on"
+# Increase upload limits to allow jenkins plugin uploads
+nginx_max_body_size: 100M
+nginx_send_timeout: 120s
 
 ## variables unset by default
 httpd_no_error_pages: false

--- a/cinch/roles/nginx/templates/etc/nginx/nginx.conf
+++ b/cinch/roles/nginx/templates/etc/nginx/nginx.conf
@@ -31,6 +31,11 @@ http {
     types_hash_max_size 2048;
     #server_names_hash_bucket_size  128;
 
+    client_body_in_file_only clean;
+    client_body_buffer_size 32K;
+    client_max_body_size {{ nginx_max_body_size }};
+    send_timeout {{ nginx_send_timeout }};
+
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 


### PR DESCRIPTION
In nginx, the default value for `client_max_body_size` is 1MB. 

This prevents one from being able to upload plugins to Jenkins from the Jenkins web UI.

This PR sets a default value of 100M (max file upload size) as a parameterized value for cinch.