### PR TITLE
Lighten up on facts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v 1.1.0
+- Removed gather_facts from upload_files roles (#218)
+
 v 1.0.0 (01 Feb 2018)
 - Update default Jenkins version to 2.60
 - Update plugins list to 2.60-friendly list

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Settings
 
 Some notable defaults for Jenkins masters currently enabled are
 - Java 8
-- Jenkins LTS 1.651.3
+- Jenkins LTS 2.63.3
 - an extensive list of plugins found in files/jenkins-plugin-lists/default.txt
 - SSL disabled, but Jenkins served off of port 80
 

--- a/cinch/group_vars/all
+++ b/cinch/group_vars/all
@@ -48,6 +48,9 @@ jswarm_filename: swarm-client-{{ jswarm_version }}-jar-with-dependencies.jar
 # module documentation for the "copy" module. Variables in this array match
 # the arguments to that module of the same name.
 # http://docs.ansible.com/ansible/copy_module.html
+# NOTE: Variables are not defined here, as the playbook group_vars/all file overrides
+# variables in the inventory file's group vars section (although they do not override
+# variables in the inventory dir's group_vars folder).
 # Example
 # pre_upload_files:
 #   - src: /home/deployuser/somehost/ssl.key
@@ -58,5 +61,3 @@ jswarm_filename: swarm-client-{{ jswarm_version }}-jar-with-dependencies.jar
 #     dest: /var/lib/jenkins/.ssh/id_rsa
 #     owner: jenkins
 #     mode: 0600
-pre_upload_files: []
-post_upload_files: []

--- a/cinch/site.yml
+++ b/cinch/site.yml
@@ -12,10 +12,11 @@
 
 - name: upload files before
   hosts: all
+  gather_facts: false
   roles:
     - role: upload_files
       vars:
-        upload_files: "{{ pre_upload_files }}"
+        upload_files: "{{ pre_upload_files | default([]) }}"
 
 - name: configure certificate authority, if necessary
   become: true
@@ -70,7 +71,8 @@
 
 - name: upload files after
   hosts: all
+  gather_facts: false
   roles:
     - role: upload_files
       vars:
-        upload_files: "{{ post_upload_files }}"
+        upload_files: "{{ post_upload_files | default([]) }}"


### PR DESCRIPTION
Reduces the burden of gather_facts on simple file uploads

Caveat: this means using {{ ansible_user_dir }} and similar facts in
variables passed into this role are going to present additional
challenges

Removed pre-defined values for pre/post-_upload_files out of the
group_vars/all file and into filter defaults. This is because of the
precedence order for variables in group_vars/all, which made this tough
to test with Vagrant.

Addresses #218