### PR TITLE
Allow nginx keytab and SSL certs to be copied from a remote source

### DIFF
--- a/cinch/roles/nginx/defaults/main.yml
+++ b/cinch/roles/nginx/defaults/main.yml
@@ -15,6 +15,12 @@ nginx_send_timeout: 120s
 ## variables unset by default
 httpd_no_error_pages: false
 https_enabled: false
+# If httpd_keytab_file, httpd_ssl_key_file, httpd_ssl_crt_file, and
+# httpd_ssl_pem_file are already present on the remote Jenkins master being
+# configured by cinch, set the following variable to true to copy the files
+# from the filesystem of the remote host rather than from the system running
+# Ansible.
+httpd_ssl_keytab_files_remote_src: false
 # local path to use as source for keytab
 httpd_keytab_file: "/THIS/FILE/PROBABLY/DOESNT/EXIST"
 # Local path to the SSL certificate to use in configuring HTTPS. Can be full or relative

--- a/cinch/roles/nginx/tasks/kerberos-setup.yml
+++ b/cinch/roles/nginx/tasks/kerberos-setup.yml
@@ -2,6 +2,7 @@
   copy:
     src: "{{ item }}"
     dest: "/etc/nginx/conf.d/httpd.keytab"
+    remote_src: "{{ httpd_ssl_keytab_files_remote_src }}"
   with_first_found:
     - files:
         - "{{ httpd_keytab_file }}"

--- a/cinch/roles/nginx/tasks/ssl-setup.yml
+++ b/cinch/roles/nginx/tasks/ssl-setup.yml
@@ -2,6 +2,7 @@
   copy:
     src: "{{ item }}"
     dest: "/etc/nginx/conf.d/ssl.key"
+    remote_src: "{{ httpd_ssl_keytab_files_remote_src }}"
     owner: nginx
     group: nginx
     mode: 0600
@@ -19,6 +20,7 @@
   copy:
     src: "{{ item }}"
     dest: "/etc/nginx/conf.d/ssl.pem"
+    remote_src: "{{ httpd_ssl_keytab_files_remote_src }}"
     owner: nginx
     group: nginx
     mode: 0644


### PR DESCRIPTION
NOTE:  please do not merge this until testing has been completed by @jpaulovic 