### PR TITLE
Allow keytab and SSL certs to be sourced from a remote host

### DIFF
--- a/cinch/roles/nginx/defaults/main.yml
+++ b/cinch/roles/nginx/defaults/main.yml
@@ -15,25 +15,23 @@ nginx_send_timeout: 120s
 ## variables unset by default
 httpd_no_error_pages: false
 https_enabled: false
-# If httpd_keytab_file, httpd_ssl_key_file, httpd_ssl_crt_file, and
-# httpd_ssl_pem_file are already present on the remote Jenkins master being
-# configured by cinch, set the following variable to true to copy the files
-# from the filesystem of the remote host rather than from the system running
-# Ansible.
+# If httpd_keytab_file, httpd_ssl_key_file and httpd_ssl_crt_file
+# are already present on the remote Jenkins master being configured by cinch,
+# set the following variable to true to copy the files from the filesystem
+# of the remote host rather than from the system running Ansible
 httpd_ssl_keytab_files_remote_src: false
 # local path to use as source for keytab
-httpd_keytab_file: "/THIS/FILE/PROBABLY/DOESNT/EXIST"
+#httpd_keytab_file: "/THIS/FILE/PROBABLY/DOESNT/EXIST"
 # Local path to the SSL certificate to use in configuring HTTPS. Can be full or relative
 # to the path from where the main playbook is run. This can be overriden if you want
 # secure access to Jenkins using your own SSL certificate. By default, a self signed
 # certificate will be created and used.
-httpd_ssl_key_file: "{{ ssl_key_file | default('/THIS/FILE/PROBABLY/DOESNT/EXIST') }}"
-# Local path to the SSL private key in crt format. For more details see comment above.
-# When using own SSL certificates, you need to override either this variable or
-# httpd_ssl_pem_file along with httpd_ssl_key_file.
-httpd_ssl_crt_file: "{{ ssl_crt_file | default('/THIS/FILE/PROBABLY/DOESNT/EXIST') }}"
+#httpd_ssl_key_file: "/THIS/FILE/PROBABLY/DOESNT/EXIST"
+# Local path to the SSL private key in crt or pem format. For more details see comment above.
+# When using own SSL certificates, you need to override either this variable
+#httpd_ssl_crt_file: "/THIS/FILE/PROBABLY/DOESNT/EXIST"
 # Local path to the SSL private key in PEM format. For more details see comment above.
-httpd_ssl_pem_file: "{{ ssl_pem_file | default('/THIS/FILE/PROBABLY/DOESNT/EXIST') }}"
+#httpd_ssl_pem_file: "/THIS/FILE/PROBABLY/DOESNT/EXIST"
 # location and CN settings for the self signed certificate
 ssl_self_signed_string: "/C=US/ST=New York/L=New York City/O=My Department/CN={{ service_name }}"
 # whether to use a speedy method to generate Diffie Hellman parameters

--- a/cinch/roles/nginx/defaults/main.yml
+++ b/cinch/roles/nginx/defaults/main.yml
@@ -15,6 +15,12 @@ nginx_send_timeout: 120s
 ## variables unset by default
 httpd_no_error_pages: false
 https_enabled: false
+# If httpd_keytab_file, httpd_ssl_key_file, httpd_ssl_crt_file, and
+# httpd_ssl_pem_file are already present on the remote Jenkins master being
+# configured by cinch, set the following variable to true to copy the files
+# from the filesystem of the remote host rather than from the system running
+# Ansible.
+httpd_ssl_keytab_files_remote_src: false
 # local path to use as source for keytab
 httpd_keytab_file: "/THIS/FILE/PROBABLY/DOESNT/EXIST"
 # Local path to the SSL certificate to use in configuring HTTPS. Can be full or relative

--- a/cinch/roles/nginx/tasks/kerberos-setup.yml
+++ b/cinch/roles/nginx/tasks/kerberos-setup.yml
@@ -1,10 +1,7 @@
 - name: copy over keytab
   copy:
-    src: "{{ item }}"
+    src: "{{ httpd_keytab_file }}"
     dest: "/etc/nginx/conf.d/httpd.keytab"
     remote_src: "{{ httpd_ssl_keytab_files_remote_src }}"
-  with_first_found:
-    - files:
-        - "{{ httpd_keytab_file }}"
-      skip: true
+  when: httpd_keytab_file is defined
   no_log: true

--- a/cinch/roles/nginx/tasks/kerberos-setup.yml
+++ b/cinch/roles/nginx/tasks/kerberos-setup.yml
@@ -2,6 +2,7 @@
   copy:
     src: "{{ item }}"
     dest: "/etc/nginx/conf.d/httpd.keytab"
+    remote_src: "{{ httpd_ssl_keytab_files_remote_src }}"
   with_first_found:
     - files:
         - "{{ httpd_keytab_file }}"

--- a/cinch/roles/nginx/tasks/ssl-setup.yml
+++ b/cinch/roles/nginx/tasks/ssl-setup.yml
@@ -1,36 +1,28 @@
 - name: copy over ssl key
   copy:
-    src: "{{ item }}"
+    src: "{{ httpd_ssl_key_file }}"
     dest: "/etc/nginx/conf.d/ssl.key"
     remote_src: "{{ httpd_ssl_keytab_files_remote_src }}"
     owner: nginx
     group: nginx
     mode: 0600
-  with_first_found:
-    - files:
-        - "{{ httpd_ssl_key_file }}"
-      skip: true
   register: setup_ssl_key
-  notify: restart nginx service
+  when: httpd_ssl_key_file is defined
   no_log: true
   tags:
     - update_ssl_certs
 
-- name: copy over ssl pem file
+- name: copy over ssl crt file
   copy:
-    src: "{{ item }}"
+    src: "{{ httpd_ssl_crt_file }}"
     dest: "/etc/nginx/conf.d/ssl.pem"
     remote_src: "{{ httpd_ssl_keytab_files_remote_src }}"
     owner: nginx
     group: nginx
     mode: 0644
-  with_first_found:
-    - files:
-        - "{{ httpd_ssl_pem_file }}"
-        - "{{ httpd_ssl_crt_file }}"
-      skip: true
   register: setup_ssl_pem
   when: setup_ssl_key|success
+  notify: restart nginx service
   tags:
     - update_ssl_certs
 

--- a/cinch/roles/nginx/tasks/ssl-setup.yml
+++ b/cinch/roles/nginx/tasks/ssl-setup.yml
@@ -2,6 +2,7 @@
   copy:
     src: "{{ item }}"
     dest: "/etc/nginx/conf.d/ssl.key"
+    remote_src: "{{ httpd_ssl_keytab_files_remote_src }}"
     owner: nginx
     group: nginx
     mode: 0600
@@ -19,6 +20,7 @@
   copy:
     src: "{{ item }}"
     dest: "/etc/nginx/conf.d/ssl.pem"
+    remote_src: "{{ httpd_ssl_keytab_files_remote_src }}"
     owner: nginx
     group: nginx
     mode: 0644


### PR DESCRIPTION
Due to a bug/feature (?) described in ansible/ansible#36299 it is not possible to apply #223. This approach works around the issue.