### PR TITLE
Stop using my fedorapeople mirror

### DIFF
--- a/cinch/group_vars/cent7
+++ b/cinch/group_vars/cent7
@@ -7,7 +7,11 @@ _repositories:
     mirrorlist: "{{ fedora_mirrors }}repo=epel-7"
 
 _download_repositories:
-  - https://fedorapeople.org/~semyers/jenkins-rpm/jenkins1651.repo
+  - https://pkg.jenkins.io/redhat-stable/jenkins.repo
+
+rpm_key_imports:
+  - key: http://pkg.jenkins-ci.org/redhat-stable/jenkins.io.key
+    validate_certs: true
 
 jenkins_slave_repositories: "{{ _repositories }}"
 jenkins_slave_download_repositories: "{{ _download_repositories }}"

--- a/cinch/group_vars/fedora
+++ b/cinch/group_vars/fedora
@@ -3,7 +3,11 @@ repositories:
     mirrorlist: "{{ fedora_mirrors }}repo=rawhide"
 
 _download_repositories:
-  - https://fedorapeople.org/~semyers/jenkins-rpm/jenkins1651.repo
+  - http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo
+
+rpm_key_imports:
+  - key: http://pkg.jenkins-ci.org/redhat-stable/jenkins.io.key
+    validate_certs: true
 
 jenkins_master_repositories: []
 jenkins_slave_repositories: []

--- a/cinch/group_vars/rhel7
+++ b/cinch/group_vars/rhel7
@@ -20,7 +20,11 @@ all_repositories:
 # These types of repositories will download the requested URL into the /etc/yum.repos.d
 # folder in order to enable them
 all_download_repositories:
-  jenkins: https://fedorapeople.org/~semyers/jenkins-rpm/jenkins1651.repo
+  jenkins: http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo
+
+rpm_key_imports:
+  - key: http://pkg.jenkins-ci.org/redhat-stable/jenkins.io.key
+    validate_certs: true
 
 jenkins_slave_repositories:
   - "{{ all_repositories.latest }}"


### PR DESCRIPTION
Now that we're not focused on 1.651, we can return to using the normal
jenkins mirrors for downloading jenkins. The slow mirror problem only
affected old releases that jenkins was no longer distributing out to all
of its mirrors, this does not affect more recent LTS releases like 2.60
and 2.89.