### PR TITLE
linchpin verson bump and AWS example support

### DIFF
--- a/cinch/playbooks/install-rhel7.yml
+++ b/cinch/playbooks/install-rhel7.yml
@@ -69,12 +69,12 @@
         virtualenv_site_packages: true
       with_dict: "{{ venvs }}"
 
-    - name: install version 1.0.4 of linchpin using pip
+    - name: install version 1.5.2 of linchpin using pip
       pip:
         name: linchpin
         virtualenv: "{{ venvs.linchpin }}"
         extra_args: -U
-        version: 1.0.4
+        version: 1.5.2
 
     - name: install released version of cinch using pip
       pip:

--- a/jjb/ci-jslave-project-sample.yaml
+++ b/jjb/ci-jslave-project-sample.yaml
@@ -10,6 +10,7 @@
           choices:
             - openstack-slave
             - beaker-slave
+            - aws_ec2-slave
     builders:
       - shell: |
             #!/bin/bash -ex


### PR DESCRIPTION
* bumped supported version of linchpin to version 1.5.2

* added an entry in the JJB workflow template for AWS EC2