### PR TITLE
Fix ShellCheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ python:  # Only one version for now
   - "2.7"
 cache: pip
 
+# Installation of the system
+addons:
+  apt:
+    packages:
+      - shellcheck
 before_install:
   - travis_retry pip install -U pip
   - pip --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,6 @@ python:  # Only one version for now
   - "2.7"
 cache: pip
 
-# Installation of the system
-addons:
-  apt:
-    sources:
-      - debian-sid
-    packages:
-      - shellcheck
 before_install:
   - travis_retry pip install -U pip
   - pip --version


### PR DESCRIPTION
Shellcheck is not used at any point and the installation of it in Travis fail. Removing it fixed Travis CI: https://travis-ci.org/abraverm/cinch/builds/393286942