### PR TITLE
Remove epel-testing

### DIFF
--- a/cinch/group_vars/cent7
+++ b/cinch/group_vars/cent7
@@ -1,8 +1,6 @@
 gcc_compat_package: compat-gcc-44
 
 _repositories:
-  - name: epel-testing
-    mirrorlist: "{{ fedora_mirrors }}repo=testing-epel7"
   - name: epel
     mirrorlist: "{{ fedora_mirrors }}repo=epel-7"
 


### PR DESCRIPTION
Having the EPEL testing repo involved was the product of a bygone era,
in the days before packages made it to the wilds of the main EPEL
repositories. This should be killed with fire.