### PR TITLE
Modify check_ssh role to use wait_for_connection module

### DIFF
--- a/cinch/roles/check_ssh/defaults/main.yml
+++ b/cinch/roles/check_ssh/defaults/main.yml
@@ -1,3 +1,2 @@
-ssh_retries: 100
+ssh_timeout: 600
 ssh_retry_delay: 6
-host: "{{ hostvars[inventory_hostname]['ansible_host'] | default(inventory_hostname) }}"

--- a/cinch/roles/check_ssh/tasks/main.yml
+++ b/cinch/roles/check_ssh/tasks/main.yml
@@ -1,23 +1,5 @@
-- block:
-  - name: verify that configured SSH private key is a file and has permissions of 0600
-    local_action: file path="{{ ansible_ssh_private_key_file }}" state=file mode=0600
-    tags:
-      - skip_ansible_lint
-
-  - name: construct command line for SSH check
-    set_fact:
-      check_ssh_cmd: >-
-        ansible --ssh-extra-args='-o StrictHostKeyChecking=no'
-        -i '{{ inventory_dir }}/{{ (inventory_file | string | default('')) | basename }}'
-        {{ host }} -m ping
-
-  - name: check for SSH connectivity and authentication
-    local_action: shell {{ check_ssh_cmd }}
-    register: result
-    changed_when: "result.rc != 0"
-    until: result.rc == 0
-    retries: "{{ ssh_retries }}"
-    delay: "{{ ssh_retry_delay }}"
-    tags:
-      - skip_ansible_lint
+- name: wait for ssh connection
+  wait_for_connection:
+    sleep: '{{ ssh_retry_delay }}'
+    timeout: '{{ ssh_timeout }}'
   when: ansible_connection == 'ssh'


### PR DESCRIPTION
- **[Modified]** Replace check_ssh role with wait_for_connection module (#227 )
- **[Removed]** Add groovy scripts that configure Jenkins in following aspects. This action gives an option for user to automatically fix security warning for newly deployed/updated Jenkins, and controled by the variable `jenkins_advised_security`, which is default as false.
    - Disable CLI -remoting mode
    - Enable CSRF Protection
    - Enable Agent to master security subsystem
    - Disable deprecated protocols

Edit: Sorry for this late modification. For the advised Jenkins security configurations, though it also works with **jenkins_security_enabled:false**, I think we could leave them for Jenkins users to decide. Another reason is that, the security warnings are mainly caused by Jenkins version 2.89, while we are now moving to 2.121. 