### PR TITLE
Travis deploys were checking older variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,22 +41,22 @@ deploy:
     distributions: "sdist bdist_wheel"
     on:
       tags: true
-      condition: $TEST = lint.sh
+      condition: $TOXENV = lint
   - provider: script
     repo: RedHatQE/cinch
     script: ./scripts/deploy.sh centos6 false
     on:
       tags: true
-      condition: $TEST = cent6_slave.sh
+      condition: $TOXENV = cent6_slave
   - provider: script
     repo: RedHatQE/cinch
     script: ./scripts/deploy.sh centos7 true
     on:
       tags: true
-      condition: $TEST = cent7_slave.sh
+      condition: $TOXENV = cent7_slave
   - provider: script
     repo: RedHatQE/cinch
     script: ./scripts/deploy.sh fedora25 false
     on:
       tags: true
-      condition: $TEST = fedora_slave.sh
+      condition: $TOXENV = fedora_slave


### PR DESCRIPTION
The past two PyPI deploys from Travis were skipped (1.0.0 and 1.1.0)
because the change from scripts to tox precipitated a change in the
variables in use. However, the deploy conditionals in the Travis file
were never updated. This should address that problem in the future