### PR TITLE
Upgrade to Python 3 for testing everything we can

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 language: python
 python:  # Only one version for now
-  - "2.7"
+  - "3.6"
 cache: pip
 
 # Installation of the system

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,10 @@ envlist =
 
 [testenv]
 basepython =
-    {docs,py27,lint}: {env:TOXPYTHON:python2.7}
-    cent{6,7}_slave,cent7_master: {env:TOXPYTHON:python2.7}
-    fedora_{master,slave}: {env:TOXPYTHON:python2.7}
+    py27: {env:TOXPYTHON:python2.7}
+    {docs,lint}: {env:TOXPYTHON:python3}
+    cent{6,7}_slave,cent7_master: {env:TOXPYTHON:python3}
+    fedora_{master,slave}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes


### PR DESCRIPTION
Python 2.7 is end of life in less than a year's time. There shouldn't be
a reason that most of the tox environments can't run in Python 3, so
let's move everything except the specific language version tests to
running python3 by default