### PR TITLE
Fix import wrappers error in python 36

### DIFF
--- a/cinch/bin/entry_point.py
+++ b/cinch/bin/entry_point.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from argparse import ArgumentParser, REMAINDER
 from os import getcwd, path
-from wrappers import call_ansible
+from .wrappers import call_ansible
 
 import sys
 


### PR DESCRIPTION
 * Fixes issue #254 by doing a relative import of the wrapper module